### PR TITLE
WDR-83 remove deprecation warning and support for 'networking.k8s.io/…

### DIFF
--- a/cloudify-manager-worker/templates/ingress.yaml
+++ b/cloudify-manager-worker/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "cloudify-manager-worker.fullname" . -}}
 {{- $httpPort := .Values.service.http.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}


### PR DESCRIPTION
remove deprecation warning and support for 'networking.k8s.io' in k8s 1.19+ versions