### PR TITLE
Add support for external postgresql database to cloudify-manager-worker

### DIFF
--- a/cloudify-manager-worker/templates/cloudify-config.yaml
+++ b/cloudify-manager-worker/templates/cloudify-config.yaml
@@ -29,21 +29,33 @@ data:
             default: {{ .Values.queue.host }}.{{.Release.Namespace}}.svc.cluster.local
 
     postgresql_client:
+      {{- if .Values.db.useExternalDB }}
+      host: {{ .Values.db.host }}
+      {{- else }}
       host: {{ .Values.db.host }}.{{.Release.Namespace}}.svc.cluster.local
+      {{- end }}
       server_db_name: {{ .Values.db.serverDBName }}
       server_username: {{ .Values.db.serverUsername }}
       server_password: {{ .Values.db.serverPassword }}
       cloudify_db_name: {{ .Values.db.cloudifyDBName }}
       cloudify_username: {{ .Values.db.cloudifyUsername }}
       cloudify_password: {{ .Values.db.cloudifyPassword }}
+      {{- if .Values.db.useExternalDB }}
+      ca_path: {{ .Values.config.postgresqlCaPath }}
+      {{- else }}
       ca_path: {{ .Values.config.caCertPath }}
+      {{- end }}
       ssl_enabled: true
       ssl_client_verification: true
     postgresql_server:
       postgres_password: {{ .Values.db.serverPassword }}
+      {{- if .Values.db.useExternalDB }}
+      ca_path: {{ .Values.config.postgresqlCaPath }}
+      {{- else }}
       ca_path: {{ .Values.config.caCertPath }}
       cert_path: {{ .Values.config.tlsCertPath }}
       key_path: {{ .Values.config.tlsKeyPath }}
+      {{- end }}
 
     prometheus:
       ca_path: {{ .Values.config.caCertPath }}
@@ -54,7 +66,11 @@ data:
     ssl_inputs:
       postgresql_client_cert_path: {{ .Values.config.tlsCertPath }}
       postgresql_client_key_path: {{ .Values.config.tlsKeyPath }}
+      {{- if .Values.db.useExternalDB }}
+      postgresql_ca_cert_path: {{ .Values.config.postgresqlCaPath }}
+      {{- else }}
       postgresql_ca_cert_path: {{ .Values.config.caCertPath }}
+      {{- end }}
       ca_cert_path: {{ .Values.config.caCertPath }}
       internal_cert_path: {{ .Values.config.tlsCertPath }}
       internal_key_path: {{ .Values.config.tlsKeyPath }}

--- a/cloudify-manager-worker/templates/statefulset.yaml
+++ b/cloudify-manager-worker/templates/statefulset.yaml
@@ -105,6 +105,11 @@ spec:
         - name: stage-user-config-volume
           mountPath: /tmp/cloudify/userConfig.json
           subPath: userConfig.json
+        {{- if .Values.db.useExternalDB }}
+        - name: cfy-pgsql-cert
+          mountPath: /mnt/cloudify-data/ssl/postgres.crt
+          subPath: postgres.crt
+        {{- end }}
       volumes:
       - name: run
         emptyDir:
@@ -161,6 +166,11 @@ spec:
       - name: cloudify-data
         persistentVolumeClaim:
           claimName: cfy-worker-pvc
+      {{- if .Values.db.useExternalDB }}
+      - name: cfy-pgsql-cert
+        secret:
+          secretName: {{ .Values.tls.pgsqlCertSecretName }}
+      {{- end }}
 
     {{- if .Values.nodeSelector }}
       nodeSelector: {{ toYaml .Values.nodeSelector | nindent 8 }}

--- a/cloudify-manager-worker/templates/statefulset.yaml
+++ b/cloudify-manager-worker/templates/statefulset.yaml
@@ -107,7 +107,7 @@ spec:
           subPath: userConfig.json
         {{- if .Values.db.useExternalDB }}
         - name: cfy-pgsql-cert
-          mountPath: /mnt/cloudify-data/ssl/postgres.crt
+          mountPath: {{ .Values.config.postgresqlCaPath }}
           subPath: postgres.crt
         {{- end }}
       volumes:

--- a/cloudify-manager-worker/values.yaml
+++ b/cloudify-manager-worker/values.yaml
@@ -23,6 +23,7 @@ image:
 
 # external DB
 db:
+  useExternalDB: false # when switched to true, it will take the FQDN for the pgsql database in host, and require CA cert in secret inputs under TLS section and config.postgresqlCaPath
   host: postgres-postgresql
   cloudifyDBName: 'cloudify_db'
   cloudifyUsername: 'cloudify'
@@ -65,6 +66,7 @@ nodeSelector: {}
 tls:
   # certificates as a secret, to secure communications between cloudify manager and postgress|rabbitmq
   secretName: cfy-certs
+  pgsqlCertSecretName: pgsql-external-cert #required for external postgresql database only
 
 # For multiple replicas of cloudify manager use NFS like storage, storageClass: 'aws-efs' (AWS example), accessMode: 'ReadWriteMany'
 # Single replica - EBS (AWS example), storageClass: 'gp2' (AWS example), accessMode: 'ReadWriteOnce'
@@ -96,6 +98,7 @@ config:
   tlsCertPath: /mnt/cloudify-data/ssl/tls.crt
   tlsKeyPath: /mnt/cloudify-data/ssl/tls.key
   caCertPath: /mnt/cloudify-data/ssl/ca.crt
+  postgresqlCaPath: /mnt/cloudify-data/ssl/postgres.crt # only required if you're using an external pgsql db
   workerCount: 4 # suggested worker count for 1vcpu manager, add more if using a stronger host
   mgmtWorkerCount: 8 # Maximum number of worker processes started by the management worker.
 


### PR DESCRIPTION
Update templates (cloudify-config.yaml and statefulset.yaml) and values.yaml in cloudify-manager-worker chart to allow external pgsql database.

Changes made:
* added boolean useExternalDB option to .Values.db - the default is false, to use cluster postgresql
* added if statement logic to templates/statefulset.yaml and templates/cloudify-config.yaml to support creating a mountpoint for a postgresql CA cert that comes from an external source, and specifying the correct hostname for the server
* added additional values to values.yaml to support specifying an alternate CA path for postgresql configs.

I've tested this with Azure Managed Postgresql hosts, and validated that these changes work to use an external DB. 