### PR TITLE
removed initContainer

### DIFF
--- a/cloudify-manager-worker/README.md
+++ b/cloudify-manager-worker/README.md
@@ -426,12 +426,6 @@ $ helm install cloudify-manager-worker cloudify-helm/cloudify-manager-worker -f 
 | db.useExternalDB | bool | `false` | When switched to true, it will take the FQDN for the pgsql database in host, and require CA cert in secret inputs under TLS section |
 | fullnameOverride | string | `"cloudify-manager-worker"` |  |
 | image | object | object | Parameters group for Docker images |
-| image.initContainer.pullPolicy | string | `"Always"` | imagePullPolicy for init container |
-| image.initContainer.repository | string | `"busybox"` | Docker image repository for init container |
-| image.initContainer.resources | object | object | resources requests and limits for init container |
-| image.initContainer.resources.limits | object | `{"cpu":0.1,"memory":"100Mi"}` | limits for init container |
-| image.initContainer.resources.requests | object | `{"cpu":0.1,"memory":"100Mi"}` | requests for init container |
-| image.initContainer.tag | string | `"1.34.1-uclibc"` | Docker image tag for init container |
 | image.pullPolicy | string | `"IfNotPresent"` | Specify a imagePullPolicy, Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'. ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images |
 | image.pullSecrets | list | `[]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
 | image.repository | string | `"cloudifyplatform/premium-cloudify-manager-worker"` | Docker image repository |

--- a/cloudify-manager-worker/README.md.gotmpl
+++ b/cloudify-manager-worker/README.md.gotmpl
@@ -99,14 +99,14 @@ You need to deploy those manifests, which will generate cfy-certs secret eventua
 You can find this manifest in external folder - cert-issuer.yaml
 
 ```yaml
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: selfsigned-issuer
 spec:
   selfSigned: {}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: cfy-ca
@@ -120,7 +120,7 @@ spec:
   issuerRef:
     name: selfsigned-issuer
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: cfy-ca-issuer
@@ -128,7 +128,7 @@ spec:
   ca:
     secretName: cfy-ca-tls
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: cfy-cert

--- a/cloudify-manager-worker/templates/statefulset.yaml
+++ b/cloudify-manager-worker/templates/statefulset.yaml
@@ -21,25 +21,6 @@ spec:
     spec:
       automountServiceAccountToken: false
       securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      initContainers:
-      - name: init-data
-        image: {{ .Values.image.initContainer.repository }}:{{ .Values.image.initContainer.tag }}
-        imagePullPolicy: {{ .Values.image.initContainer.pullPolicy }}
-        {{- if .Values.image.initContainer.resources }}
-        resources: {{- toYaml .Values.image.initContainer.resources | nindent 10 }}
-        {{- end }}
-        securityContext: {{- toYaml .Values.containerSecurityContext | nindent 10 }}
-        command:
-          - /bin/sh
-          - -cx
-          - |
-            mkdir -p /mnt/cloudify-data/ssl
-            cp /tmp/ssl/* /mnt/cloudify-data/ssl
-        volumeMounts:
-        - name: cfy-worker-certs
-          mountPath: /tmp/ssl
-        - name: cloudify-data
-          mountPath: /mnt/cloudify-data
       containers:
       - name: {{ template "cloudify-manager-worker.name" . }}
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
@@ -112,6 +93,15 @@ spec:
           subPath: after_hook.sh
         - name: cloudify-data
           mountPath: /mnt/cloudify-data
+        - name: cfy-worker-certs
+          mountPath: {{ .Values.tlsCertPath }}
+          subPath: tls.crt
+        - name: cfy-worker-certs
+          mountPath: {{ .Values.tlsKeyPath }}
+          subPath: tls.key
+        - name: cfy-worker-certs
+          mountPath: {{ .Values.caCertPath }}
+          subPath: ca.crt
         {{- if .Values.okta.enabled }}
         - name: okta-license-volume
           mountPath: /mnt/cloudify-data/ssl/okta_certificate.pem

--- a/cloudify-manager-worker/templates/statefulset.yaml
+++ b/cloudify-manager-worker/templates/statefulset.yaml
@@ -94,13 +94,13 @@ spec:
         - name: cloudify-data
           mountPath: /mnt/cloudify-data
         - name: cfy-worker-certs
-          mountPath: {{ .Values.tlsCertPath }}
+          mountPath: {{ .Values.config.tlsCertPath }}
           subPath: tls.crt
         - name: cfy-worker-certs
-          mountPath: {{ .Values.tlsKeyPath }}
+          mountPath: {{ .Values.config.tlsKeyPath }}
           subPath: tls.key
         - name: cfy-worker-certs
-          mountPath: {{ .Values.caCertPath }}
+          mountPath: {{ .Values.config.caCertPath }}
           subPath: ca.crt
         {{- if .Values.okta.enabled }}
         - name: okta-license-volume

--- a/cloudify-manager-worker/values.yaml
+++ b/cloudify-manager-worker/values.yaml
@@ -13,24 +13,6 @@ image:
   # -- Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
   pullSecrets: []
   # - name: secretName
-  initContainer:
-    # -- Docker image repository for init container
-    repository: busybox
-    # -- Docker image tag for init container
-    tag: 1.34.1-uclibc
-    # -- imagePullPolicy for init container
-    pullPolicy: Always
-    # -- resources requests and limits for init container
-    # @default -- object
-    resources:
-      # -- requests for init container
-      requests:
-        memory: 100Mi
-        cpu: 0.1
-      # -- limits for init container
-      limits:
-        memory: 100Mi
-        cpu: 0.1
 
 # -- Parameters group for connection to PostgreSQL database
 # @default -- object


### PR DESCRIPTION
InitContainer is not a must in our configuration, it can be replaced by mounting certificates from secrets like we do for other secrets, through the main container (cloudify-worker)