### PR TITLE
RD-5681: optional using custom public_ip parameter

### DIFF
--- a/cloudify-manager-worker/README.md
+++ b/cloudify-manager-worker/README.md
@@ -355,7 +355,9 @@ Use ingress-controller (e.g. NGINX Ingress Controller - https://kubernetes.githu
 
 ### **[OPTION 2]**
 
-Skip Ingress and expose the Cloudify Manager service using LoadBalancer
+Skip Ingress and expose the Cloudify Manager service using LoadBalancer.
+
+To have a fixed URL, you must utilize a DNS service to route the LB URL (hostname) to the URL you want.
 
 **HTTP**
 
@@ -374,19 +376,28 @@ service:
     port: 53333
 ```
 
-That will create a load balancer depending on your K8S infrastructure (e.g. EKS will create a Classic Load Balancer)
+That will create a load balancer depending on your K8S infrastructure (e.g. EKS will create a Classic Load Balancer).
+
+Also please add parameter **config.public_ip** with DNS name which you are going to configure for you Cloudify Manager  load balancer endpoint, for example:
+
+```yaml
+config:
+  public_ip: cloudify-manager.example.com
+```
+
 **To get the hostname of the load balancer run:**
 
 ```bash
 $ kubectl describe svc/cloudify-manager-worker -n NAMESPACE | grep Ingress
 ```
 
+Then you can configure DNS record (ALIAS type), points to this load balancer hostname.
+
 **The value of the ingress will be the UI URL of the Cloudify Manager.**
 
 **HTTPS**
 
 - To secure the site with SSL you can update the load balancer configuration to utilize an SSL Certificate
-- To have a fixed URL, you can utilize a DNS service to route the LB URL (hostname) to the URL you want
 
 ### After values are verified, install the manager worker chart
 
@@ -404,6 +415,8 @@ $ helm install cloudify-manager-worker cloudify-helm/cloudify-manager-worker -f 
 | config.cliLocalProfileHostName | string | `"localhost"` | "manager.cli_local_profile_host_name" parameter from Cloudify Manager config.yaml file. |
 | config.labels | object | `{}` | Add labels to Manager-worker container (see example below).   example-label: "cloudify-example" |
 | config.mgmtWorkerCount | int | `8` | Maximum number of worker processes started by the management worker. |
+| config.private_ip | string | `nil` | "manager.private_ip" parameter from Cloudify Manager config.yaml file. If is not set, will be calculated automatically. |
+| config.public_ip | string | `nil` | "manager.public_ip" parameter from Cloudify Manager config.yaml file. If is not set, will be calculated automatically. |
 | config.replicas | int | `1` | Replicas count for launch. Multiple replicas works only with NFS like volume. |
 | config.security.adminPassword | string | `"admin"` | Initial admin password for Cloudify Manager. |
 | config.security.sslEnabled | bool | `false` | Enable SSL for Cloudify Manager. |

--- a/cloudify-manager-worker/README.md.gotmpl
+++ b/cloudify-manager-worker/README.md.gotmpl
@@ -355,7 +355,9 @@ Use ingress-controller (e.g. NGINX Ingress Controller - https://kubernetes.githu
 
 ### **[OPTION 2]**
 
-Skip Ingress and expose the Cloudify Manager service using LoadBalancer
+Skip Ingress and expose the Cloudify Manager service using LoadBalancer.
+
+To have a fixed URL, you must utilize a DNS service to route the LB URL (hostname) to the URL you want.
 
 **HTTP**
 
@@ -374,19 +376,29 @@ service:
     port: 53333
 ```
 
-That will create a load balancer depending on your K8S infrastructure (e.g. EKS will create a Classic Load Balancer)
+That will create a load balancer depending on your K8S infrastructure (e.g. EKS will create a Classic Load Balancer).
+
+
+Also please add parameter **config.public_ip** with DNS name which you are going to configure for you Cloudify Manager  load balancer endpoint, for example:
+
+```yaml
+config:
+  public_ip: cloudify-manager.example.com
+```
+
 **To get the hostname of the load balancer run:**
 
 ```bash
 $ kubectl describe svc/cloudify-manager-worker -n NAMESPACE | grep Ingress
 ```
 
+Then you can configure DNS record (ALIAS type), points to this load balancer hostname.
+
 **The value of the ingress will be the UI URL of the Cloudify Manager.**
 
 **HTTPS**
 
 - To secure the site with SSL you can update the load balancer configuration to utilize an SSL Certificate
-- To have a fixed URL, you can utilize a DNS service to route the LB URL (hostname) to the URL you want
 
 ### After values are verified, install the manager worker chart
 

--- a/cloudify-manager-worker/templates/_helpers.tpl
+++ b/cloudify-manager-worker/templates/_helpers.tpl
@@ -43,3 +43,27 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
+
+{{/*
+Define value for manager.public_ip parameter in cloudify main config file
+*/}}
+{{- define "cloudify-manager-worker.public_ip" -}}
+{{- if .Values.config.public_ip -}}
+    {{- .Values.config.public_ip -}}
+{{- else if .Values.ingress.enabled -}}
+    {{- .Values.ingress.host -}}
+{{- else -}}
+    {{- printf "%s.%s.%s" .Values.service.host .Release.Namespace "svc.cluster.local" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Define value for manager.private_ip parameter in cloudify main config file
+*/}}
+{{- define "cloudify-manager-worker.private_ip" -}}
+{{- if .Values.config.private_ip -}}
+    {{- .Values.config.private_ip -}}
+{{- else -}}
+    {{- printf "%s.%s.%s" .Values.service.host .Release.Namespace "svc.cluster.local" -}}
+{{- end -}}
+{{- end -}}

--- a/cloudify-manager-worker/templates/cloudify-config.yaml
+++ b/cloudify-manager-worker/templates/cloudify-config.yaml
@@ -1,3 +1,5 @@
+{{- $public_ip := include "cloudify-manager-worker.public_ip" . -}}
+{{- $private_ip := include "cloudify-manager-worker.private_ip" . -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -5,8 +7,8 @@ metadata:
 data:
   config.yaml: |
     manager:
-      private_ip: {{ .Values.service.host }}.{{.Release.Namespace}}.svc.cluster.local
-      public_ip: {{ .Values.service.host }}.{{.Release.Namespace}}.svc.cluster.local
+      private_ip: {{ $private_ip }}
+      public_ip: {{ $public_ip }}
       hostname: {{ .Values.service.host }}.{{.Release.Namespace}}.svc.cluster.local
       cli_local_profile_host_name: {{ .Values.config.cliLocalProfileHostName }}
       security:

--- a/cloudify-manager-worker/values.yaml
+++ b/cloudify-manager-worker/values.yaml
@@ -129,6 +129,10 @@ config:
   after_bash: ""
   # -- "manager.cli_local_profile_host_name" parameter from Cloudify Manager config.yaml file.
   cliLocalProfileHostName: localhost
+  # -- "manager.public_ip" parameter from Cloudify Manager config.yaml file. If is not set, will be calculated automatically.
+  public_ip:
+  # -- "manager.private_ip" parameter from Cloudify Manager config.yaml file. If is not set, will be calculated automatically.
+  private_ip:
   security:
     # -- Enable SSL for Cloudify Manager.
     sslEnabled: false


### PR DESCRIPTION
Order for public_ip parameter:
1. custom value
2. Ingress host
3. fallback to internal name in k8s cluster

Order for private_ip parameter:
1. custom value
3. fallback to internal name in k8s cluster