### PR TITLE
Always use up-to-date configMaps in manager-worker startup

### DIFF
--- a/cloudify-manager-worker/templates/before_hook.yaml
+++ b/cloudify-manager-worker/templates/before_hook.yaml
@@ -19,6 +19,10 @@ data:
     mkdir -p /mnt/cloudify-data/cloudify-stage
     mkdir -p /mnt/cloudify-data/latest
 
+    # Config Maps are mounted to /tmp. They should be copied each restart to the PV
+    cp -a --verbose /tmp/cloudify/userConfig.json $CLOUDIFY_DATA_DIR/cloudify-stage/userConfig.json
+    cp -a --verbose /tmp/cloudify/config.yaml $CLOUDIFY_DATA_DIR/etc/config.yaml
+
     if [ -f "$FILE" ]; then
       echo "The Data exists on PV - creating symbolic links to files and folders on PV"
       rm -f /etc/cloudify/config.yaml


### PR DESCRIPTION
Ensure the manager always references the latest userConfig.json and config.yaml config maps.

Previously, if the manager had been initialized, updates to config.yaml or userConfig.json wouldn't be reloaded at next pod restart. 

This caused problems in a manager 6.4.0 to 6.4.1 upgrade, and would also cause issues if a user attempted to scale worker processes or other intrinsic configurations between pod restarts using Helm or other configuration management.