### PR TITLE
Allow more flexibility in Ingress Controller and another option for License import

### DIFF
--- a/cloudify-manager-worker/templates/ingress.yaml
+++ b/cloudify-manager-worker/templates/ingress.yaml
@@ -12,6 +12,9 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
   {{- if .Values.ingress.tls.enabled }}
   tls:
     - hosts:

--- a/cloudify-manager-worker/templates/statefulset.yaml
+++ b/cloudify-manager-worker/templates/statefulset.yaml
@@ -146,7 +146,11 @@ spec:
       - name: cloudify-cfg-volume
         configMap:
           name: cloudify-config
-      {{- if .Values.license }}
+      {{- if .Values.license.useSecret }}
+      - name: cloudify-license-volume
+        secret:
+          secretName: {{ .Values.license.secretName }}
+      {{- else if .Values.license }}
       - name: cloudify-license-volume
         configMap:
           name: {{ .Values.license.secretName }}

--- a/cloudify-manager-worker/values.yaml
+++ b/cloudify-manager-worker/values.yaml
@@ -261,6 +261,8 @@ ingress:
   enabled: false
   # -- Hostname for ingress connection
   host: cfy-efs-app.eks.cloudify.co
+  # Optional Ingress Class Name, instead of using the ingress annotation. A more current approach to ingress controllers
+  #ingressClassName: nginx
   # -- Ingress annotation object. Please see an example in values.yaml file
   # @default -- object
   annotations:

--- a/cloudify-manager-worker/values.yaml
+++ b/cloudify-manager-worker/values.yaml
@@ -188,6 +188,8 @@ okta:
 license: {}
 # license:
 #   secretName: cfy-license
+# optionally use a secret instead of configMap for the license file
+#   useSecret: true 
 
 # -- Parameters group for pod liveness probe
 # @default -- object


### PR DESCRIPTION
Two features we are actively using downstream - ingressClassName and secret value for the Cloudify license, instead of using a config map. 

Happy to take alternative implementations in the values file, but hoping we can upstream these changes, to ease our administrative burden in managing our own copy of the helm chart.