### PR TITLE
Add license and ingressclass options

### DIFF
--- a/cloudify-manager-worker/README.md
+++ b/cloudify-manager-worker/README.md
@@ -165,11 +165,10 @@ $ git clone https://github.com/cloudify-cosmo/cloudify-helm.git && cd cloudify-h
 
 ## Install cloudify manager worker
 
-### Create configMap with premium license - required if using Cloudify premium version
+### Create secret/configMap with premium license - required if using Cloudify premium version
 
 Create license.yaml file and populate it with license data
 
-- American/British English conventions accepted, but must be alligned across all 'license/licence' strings (values/configMaps)
 
 ```yaml
 apiVersion: v1
@@ -674,7 +673,9 @@ Some common use cases:
 
 This might happen if the English convention of licence/license is not alligned across the values (name of the value and its value), or across the license/licence configMap.
 
-Also, the [StatefulSet](./templates/statefulset.yaml) accepts a license/licence [configMap](#create-configmap-with-premium-license---required-if-using-cloudify-premium-version) with the `data` value of this syntax `cfy_license.yaml` (according to the chosen English convention)
+Since v0.4.1 `licence` convention is not supported. please use `license`.
+
+The [StatefulSet](./templates/statefulset.yaml) accepts a [secret/configMap](#create-secret/configmap-with-premium-license---required-if-using-cloudify-premium-version) with the `data` value of this syntax `cfy_license.yaml` (according to the chosen English convention)
 
 After ensuring the above, try to reinstall the worker chart
 

--- a/cloudify-manager-worker/README.md
+++ b/cloudify-manager-worker/README.md
@@ -405,7 +405,7 @@ $ helm install cloudify-manager-worker cloudify-helm/cloudify-manager-worker --v
 | initContainers.waitDependencies.resources.requests | object | `{"cpu":0.1,"memory":"50Mi"}` | requests for wait-for-dependencies init container |
 | initContainers.waitDependencies.tag | string | `"1.34.1-uclibc"` | Docker image tag for wait-for-dependencies init container |
 | initContainers.waitDependencies.timeout | string | `"10m"` | timeout for waiting when all dependencies up |
-| license | object | `{}` | Can contain "secretName" field with existing in k8s configMap name contains cloudify manager license file. license/licence conventions are accepted - make sure to allign the convention across the values file (This line and secret name) & in the configMap itself (See docs for more information) |
+| license | object | `{}` | Can contain "secretName" field with existing in k8s configMap name contains cloudify manager license file. |
 | livenessProbe | object | object | Parameters group for pod liveness probe |
 | livenessProbe.enabled | bool | `true` | Enable liveness probe |
 | livenessProbe.failureThreshold | int | `8` | liveness probe failure threshold |

--- a/cloudify-manager-worker/README.md
+++ b/cloudify-manager-worker/README.md
@@ -169,7 +169,6 @@ $ git clone https://github.com/cloudify-cosmo/cloudify-helm.git && cd cloudify-h
 
 Create license.yaml file and populate it with license data
 
-
 ```yaml
 apiVersion: v1
 kind: ConfigMap
@@ -229,7 +228,7 @@ To do that please ensure you have following parameters in the values file:
 ```yaml
 postgresql:
   deploy: true
- 
+
 rabbitmq:
   deploy: true
 ```
@@ -404,7 +403,7 @@ $ helm install cloudify-manager-worker cloudify-helm/cloudify-manager-worker --v
 | initContainers.waitDependencies.resources.requests | object | `{"cpu":0.1,"memory":"50Mi"}` | requests for wait-for-dependencies init container |
 | initContainers.waitDependencies.tag | string | `"1.34.1-uclibc"` | Docker image tag for wait-for-dependencies init container |
 | initContainers.waitDependencies.timeout | string | `"10m"` | timeout for waiting when all dependencies up |
-| license | object | `{}` | Can contain "secretName" field with existing in k8s configMap name contains cloudify manager license file. |
+| license | object | `{}` | Can contain "secretName" field with existing license in k8s configMap, to use Secret instead, set useSecret to true. |
 | livenessProbe | object | object | Parameters group for pod liveness probe |
 | livenessProbe.enabled | bool | `true` | Enable liveness probe |
 | livenessProbe.failureThreshold | int | `8` | liveness probe failure threshold |
@@ -671,11 +670,11 @@ Some common use cases:
 
 ### License is not uploaded correctly upon installation
 
-This might happen if the English convention of licence/license is not alligned across the values (name of the value and its value), or across the license/licence configMap.
+[deprecated] This might happen if the English convention of licence/license is not alligned across the values (name of the value and its value), or across the license/licence configMap.
 
 Since v0.4.1 `licence` convention is not supported. please use `license`.
 
-The [StatefulSet](./templates/statefulset.yaml) accepts a [secret/configMap](#create-secret/configmap-with-premium-license---required-if-using-cloudify-premium-version) with the `data` value of this syntax `cfy_license.yaml` (according to the chosen English convention)
+The [StatefulSet](./templates/statefulset.yaml) accepts a [secret/configMap](#create-secret/configmap-with-premium-license---required-if-using-cloudify-premium-version) with the `data` value of this syntax `cfy_license.yaml`
 
 After ensuring the above, try to reinstall the worker chart
 

--- a/cloudify-manager-worker/README.md.gotmpl
+++ b/cloudify-manager-worker/README.md.gotmpl
@@ -230,7 +230,7 @@ To do that please ensure you have following parameters in the values file:
 ```yaml
 postgresql:
   deploy: true
-  
+ 
 rabbitmq:
   deploy: true
 ```
@@ -323,7 +323,6 @@ service:
 ```
 
 That will create a load balancer depending on your K8S infrastructure (e.g. EKS will create a Classic Load Balancer).
-
 
 Also please add parameter **config.public_ip** with DNS name which you are going to configure for you Cloudify Manager  load balancer endpoint, for example:
 

--- a/cloudify-manager-worker/README.md.gotmpl
+++ b/cloudify-manager-worker/README.md.gotmpl
@@ -165,11 +165,10 @@ $ git clone https://github.com/cloudify-cosmo/cloudify-helm.git && cd cloudify-h
 
 ## Install cloudify manager worker
 
-### Create configMap with premium license - required if using Cloudify premium version
+### Create secret/configMap with premium license - required if using Cloudify premium version
 
 Create license.yaml file and populate it with license data
 
-- American/British English conventions accepted, but must be alligned across all 'license/licence' strings (values/configMaps)
 
 ```yaml
 apiVersion: v1
@@ -558,9 +557,11 @@ Some common use cases:
 
 ### License is not uploaded correctly upon installation
 
-This might happen if the English convention of licence/license is not alligned across the values (name of the value and its value), or across the license/licence configMap.
+[deprecated] This might happen if the English convention of licence/license is not alligned across the values (name of the value and its value), or across the license/licence configMap.
 
-Also, the [StatefulSet](./templates/statefulset.yaml) accepts a license/licence [configMap](#create-configmap-with-premium-license---required-if-using-cloudify-premium-version) with the `data` value of this syntax `cfy_license.yaml` (according to the chosen English convention)
+Since v0.4.1 `licence` convention is not supported. please use `license`.
+
+The [StatefulSet](./templates/statefulset.yaml) accepts a [secret/configMap](#create-secret/configmap-with-premium-license---required-if-using-cloudify-premium-version) with the `data` value of this syntax `cfy_license.yaml`
 
 After ensuring the above, try to reinstall the worker chart
 

--- a/cloudify-manager-worker/templates/ingress.yaml
+++ b/cloudify-manager-worker/templates/ingress.yaml
@@ -12,6 +12,9 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
   {{- if .Values.ingress.tls.enabled }}
   tls:
     - hosts:

--- a/cloudify-manager-worker/templates/statefulset.yaml
+++ b/cloudify-manager-worker/templates/statefulset.yaml
@@ -177,14 +177,14 @@ spec:
       - name: cloudify-cfg-volume
         configMap:
           name: cloudify-config
-      {{- if .Values.license }}
+      {{- if .Values.license.useSecret }}
       - name: cloudify-license-volume
-        configMap:
-          name: {{ .Values.license.secretName }}
-      {{- else if .Values.licence }} # add option to accept legacy 'licence' instead of 'license'
-      - name: cloudify-licence-volume
-        configMap:
-          name: {{ .Values.licence.secretName }}
+        secret:
+          secretName: {{ .Values.license.secretName }}
+      {{- else if .Values.license }}
+       - name: cloudify-license-volume
+         configMap:
+           name: {{ .Values.license.secretName }}
       {{- end }}
       {{- if .Values.okta.enabled }}
       - name: okta-license-volume

--- a/cloudify-manager-worker/templates/statefulset.yaml
+++ b/cloudify-manager-worker/templates/statefulset.yaml
@@ -182,9 +182,9 @@ spec:
         secret:
           secretName: {{ .Values.license.secretName }}
       {{- else if .Values.license }}
-       - name: cloudify-license-volume
-         configMap:
-           name: {{ .Values.license.secretName }}
+      - name: cloudify-license-volume
+        configMap:
+          name: {{ .Values.license.secretName }}
       {{- end }}
       {{- if .Values.okta.enabled }}
       - name: okta-license-volume

--- a/cloudify-manager-worker/values.yaml
+++ b/cloudify-manager-worker/values.yaml
@@ -210,10 +210,11 @@ okta:
   portalUrl: ""
 
 # -- Can contain "secretName" field with existing in k8s configMap name contains cloudify manager license file.
-# license/licence conventions are accepted - make sure to allign the convention across the values file (This line and secret name) & in the configMap itself (See docs for more information)
 license: {}
 # license:
 #   secretName: cfy-license
+# -- optionally use a secret instead of configMap for the license file
+#   useSecret: true 
 
 # -- Parameters group for pod liveness probe
 # @default -- object
@@ -285,6 +286,8 @@ ingress:
   enabled: false
   # -- Hostname for ingress connection
   host: cfy-efs-app.eks.cloudify.co
+  # -- Optional Ingress Class Name, instead of using the ingress annotation.
+  # ingressClassName: nginx
   # -- Ingress annotation object. Please see an example in values.yaml file
   # @default -- object
   annotations:

--- a/cloudify-manager-worker/values.yaml
+++ b/cloudify-manager-worker/values.yaml
@@ -209,7 +209,7 @@ okta:
   # -- Portal URL
   portalUrl: ""
 
-# -- Can contain "secretName" field with existing license in k8s configMap. to use Secret instead, set useSecret to true.
+# -- Can contain "secretName" field with existing license in k8s configMap, to use Secret instead, set useSecret to true.
 license: {}
 # license:
 #   secretName: cfy-license

--- a/cloudify-manager-worker/values.yaml
+++ b/cloudify-manager-worker/values.yaml
@@ -209,7 +209,7 @@ okta:
   # -- Portal URL
   portalUrl: ""
 
-# -- Can contain "secretName" field with existing in k8s configMap name contains cloudify manager license file.
+# -- Can contain "secretName" field with existing license in k8s configMap. to use Secret instead, set useSecret to true.
 license: {}
 # license:
 #   secretName: cfy-license


### PR DESCRIPTION
Updated suggested changes by customer from PR #55 
For v0.4.1 - will need to update changeLog with the deprecation of 'licence' convention, and the addition of the options:
1. license as a secret
2. ingressClass definition instead of in annotation