### PR TITLE
RD-7052 Run configure_manager in RESTservice

### DIFF
--- a/cloudify-services/templates/api-service.yaml
+++ b/cloudify-services/templates/api-service.yaml
@@ -24,19 +24,7 @@ spec:
             - bash
             - -exuc
             - |
-              export CONFIG_FILE="${CONFIG_FILE_PATH:-/tmp/config.yaml}"
-              if [ ! -e "${CONFIG_FILE}" ] ; then
-                echo "
-                manager:
-                  hostname: cloudify-manager
-                  private_ip: ${ENTRYPOINT}
-                " > "${CONFIG_FILE}"
-                #postgresql_client:
-                #  host: postgresql
-                #  server_db_name: cloudify_db
-                #  server_username: cloudify
-                #  server_password: cloudify
-              fi
+              /opt/rest-service/docker/prepare_secrets.sh
               python -m manager_rest.configure_manager --db-wait postgresql
           env:
             - name: ENTRYPOINT

--- a/cloudify-services/templates/api-service.yaml
+++ b/cloudify-services/templates/api-service.yaml
@@ -17,7 +17,7 @@ spec:
       initContainers:
         - name: api-service-init
           image: {{ .Values.rest_service.image }}
-          imagePullPolicy: {{ .Values.api_service.imagePullPolicy }}
+          imagePullPolicy: {{ .Values.rest_service.imagePullPolicy }}
           command:
             - /usr/bin/env
             - -S

--- a/cloudify-services/templates/mgmtworker.yaml
+++ b/cloudify-services/templates/mgmtworker.yaml
@@ -24,7 +24,8 @@ spec:
             - |
               /opt/rest-service/docker/prepare_secrets.sh
               python -m manager_rest.configure_manager --rabbitmq-wait rabbitmq
-              python -m manager_rest.configure_manager -c /tmp/config.yaml --create-admin-token /opt/mgmtworker/work/admin_token
+              python -m manager_rest.configure_manager --db-wait postgresql
+              python -m manager_rest.configure_manager --create-admin-token /opt/mgmtworker/work/admin_token
           env:
             - name: ENTRYPOINT
               value: nginx

--- a/cloudify-services/templates/mgmtworker.yaml
+++ b/cloudify-services/templates/mgmtworker.yaml
@@ -23,15 +23,6 @@ spec:
             - -exuc
             - |
               /opt/rest-service/docker/prepare_secrets.sh
-              export "CONFIG_FILE=${CONFIG_FILE_PATH:-/tmp/config.yaml}"
-              if [ ! -e "${CONFIG_FILE}" ] ; then
-                echo "
-                manager:
-                  hostname: cloudify-manager
-                  private_ip: ${ENTRYPOINT}
-                  file_server_type: s3
-                " > "${CONFIG_FILE}"
-              fi
               python -m manager_rest.configure_manager --rabbitmq-wait rabbitmq
               python -m manager_rest.configure_manager -c /tmp/config.yaml --create-admin-token /opt/mgmtworker/work/admin_token
           env:

--- a/cloudify-services/templates/rest-service.yaml
+++ b/cloudify-services/templates/rest-service.yaml
@@ -25,18 +25,24 @@ spec:
             - -exuc
             - |
               /opt/rest-service/docker/prepare_secrets.sh
-              export CONFIG_FILE="${CONFIG_FILE_PATH:-/tmp/config.yaml}"
-              if [ ! -e "${CONFIG_FILE}" ] ; then
-                echo "
-                manager:
-                  hostname: cloudify-manager
-                  private_ip: ${ENTRYPOINT}
-                  file_server_type: s3
-                " > "${CONFIG_FILE}"
-              fi
               python -m manager_rest.configure_manager --db-wait postgresql
+
               cd /opt/rest-service/migrations
               alembic upgrade head
+
+              CONFIG_FILE="/tmp/config.yaml"
+              echo "
+              restservice:
+                log:
+                  level: DEBUG
+              manager:
+                hostname: cloudify-manager
+                private_ip: ${ENTRYPOINT}
+                internal_rest_port: 443
+                file_server_type: s3
+              " > "${CONFIG_FILE}"
+
+              python -m manager_rest.configure_manager -c "${CONFIG_FILE}"
           env:
             - name: ENTRYPOINT
               value: localhost

--- a/cloudify-services/templates/rest-service.yaml
+++ b/cloudify-services/templates/rest-service.yaml
@@ -46,6 +46,10 @@ spec:
           env:
             - name: ENTRYPOINT
               value: localhost
+          volumeMounts:
+            - mountPath: /etc/cloudify/ssl
+              name: ssl
+              readOnly: true
         {{ if .Values.fileserver.install }}
         - name: fileserver-create-resources-bucket
           image: {{ .Values.fileserver.client_image }}
@@ -92,6 +96,11 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
       {{- end }}
+      volumes:
+        - name: ssl
+          secret:
+            secretName: {{ template "cloudify-services.name" . }}-certs
+            optional: false
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Before, it was (accidentally, I think) only started in the... mgmtworker initcontainer, by way of the `--create-admin-token`.

Now, after cloudify-cosmo/cloudify-manager#4072 `--create-admin-token` will no longer imply also running configuration.

So we can clean up a bit, and clearly show where do we only wait for db, where do we only create the admin token, and where do we actually run the configuration.