### PR TITLE
RND-180 "Pod status" prometheus exporter

### DIFF
--- a/cloudify-services/monitoring-configs/exporter.py
+++ b/cloudify-services/monitoring-configs/exporter.py
@@ -1,0 +1,70 @@
+"""exporter.py: a script that re-exposes pod statuses in a prometheus format
+
+This runs a HTTP server on 127.0.0.1:8000 that responds to any GET with
+a text response containing the up{} metric for every pod found in the local
+k8s namespace.
+"""
+import json
+import os
+import pathlib
+import ssl
+import http.server
+import urllib.request
+
+
+def get_metrics():
+    """Return metrics based on the pods response from the k8s api.
+
+    Fetch the list of pods in the current namespace, and return them in the
+    format of prometheus.
+    For example, this will return a list like:
+    ['up{job="rest-service", instance="192.168.2.2"}']
+    """
+    sa_dir = pathlib.Path('/var/run/secrets/kubernetes.io/serviceaccount')
+    k8s_addr = os.environ['KUBERNETES_SERVICE_HOST']
+    namespace = (sa_dir / 'namespace').read_text()
+    token = (sa_dir / 'token').read_text()
+
+    url = f'https://{k8s_addr}/api/v1/namespaces/{namespace}/pods'
+    sslcontext = ssl.create_default_context()
+    sslcontext.load_verify_locations(cafile=sa_dir / 'ca.crt')
+
+    with urllib.request.urlopen(
+        urllib.request.Request(
+            url,
+            method='GET',
+            headers={'Authorization': f'Bearer {token}'},
+        ),
+        context=sslcontext,
+    ) as req:
+        pods = json.load(req)
+
+    parts = []
+    for pod in pods['items']:
+        try:
+            app = pod['metadata']['labels']['app']
+            pod_ip = pod['status']['podIP']
+            is_up = all(
+                cs['ready'] for cs in pod['status']['containerStatuses']
+            )
+        except KeyError:
+            continue
+        parts.append(
+            f'up{{job="{app}", instance="{pod_ip}"}} {1 if is_up else 0}'
+        )
+    return '\n'.join(parts).encode()
+
+
+class MetricsHandler(http.server.BaseHTTPRequestHandler):
+    """A Handler that always returns 200 with the result of get_metrics()"""
+
+    def do_GET(self):
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(get_metrics() + b'\n')
+
+
+if __name__ == '__main__':
+    server_address = ('127.0.0.1', 8000)
+    with http.server.HTTPServer(server_address, MetricsHandler) as httpd:
+        httpd.serve_forever()

--- a/cloudify-services/monitoring-configs/prometheus.yml
+++ b/cloudify-services/monitoring-configs/prometheus.yml
@@ -1,0 +1,11 @@
+global:
+  scrape_interval: 5s
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: [ 'localhost:9090' ]
+  - job_name: 'cloudify'
+    honor_labels: true
+    static_configs:
+      - targets: [ 'localhost:8000' ]
+

--- a/cloudify-services/templates/prometheus.yaml
+++ b/cloudify-services/templates/prometheus.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -14,12 +15,41 @@ spec:
       labels:
         app: prometheus
     spec:
+      serviceAccountName: prometheus-sa
       containers:
         - image: {{ .Values.prometheus.image }}
           imagePullPolicy: {{ .Values.prometheus.imagePullPolicy }}
           name: prometheus
           ports:
             - containerPort: {{ .Values.prometheus.api_port }}
+          volumeMounts:
+            - name: prometheus-config-volume
+              mountPath: /etc/prometheus
+        # to fetch the status of all local pods, run a separate "exporter"
+        # container, running a script that will serve http on localhost,
+        # reporting all the pods fetched from the local k8s namespace.
+        # In order to be able to fetch the pods, this pod must be run
+        # using a ServiceAccount that is allowed to list pods.
+        # Currently, there doesn't seem to be a simpler way to expose
+        # "which pods are ready" to prometheus.
+        - name: cloudify-exporter
+          # we need any image that has python3.8+ on it; the restservice
+          # image is OK, and we'll avoid downloading additional images
+          image: {{ .Values.rest_service.image }}
+          imagePullPolicy: {{ .Values.rest_service.imagePullPolicy }}
+          command: ['python3', '/exporter.py']
+          volumeMounts:
+            - name: services-exporter
+              mountPath: /exporter.py
+              subPath: exporter.py
+              readOnly: true
+      volumes:
+        - name: services-exporter
+          configMap:
+            name: cloudify-services-exporter-source
+        - name: prometheus-config-volume
+          configMap:
+            name: prometheus-config
       restartPolicy: Always
 ---
 apiVersion: v1
@@ -32,3 +62,53 @@ spec:
   selector:
     app: prometheus
   type: ClusterIP
+
+# define ServiceAccount, Role, and a binding, so that the exporter container
+# is allowed to list pods
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-user-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-role
+subjects:
+- kind: ServiceAccount
+  name: prometheus-sa
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+data:
+  prometheus.yml: |-
+{{ .Files.Get "monitoring-configs/prometheus.yml" | indent 4}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cloudify-services-exporter-source
+data:
+  exporter.py: |
+{{ .Files.Get "monitoring-configs/exporter.py" | indent 4 }}
+


### PR DESCRIPTION
The aim of this is: we want a simple "status of Cloudify pods" metric in Prometheus.

It doesn't seem to be very easy to do using the usual Prometheus charts and methods, because they all seem to expect to monitor actual services, each of which exposes a `/metrics`, but there's not much about monitoring the pod status, i.e. essentially monitoring k8s itself.

So, this PR implements a simple exporter, that queries the k8s API for the list of pods, and returns their status in the format of Prometheus metrics, via HTTP. It's a very simple stdlib-python server.

With this, Prometheus has access to metrics like:
```
up{instance="10.244.0.68", job="execution-scheduler"} | 1
up{instance="10.244.0.69", job="api-service"} | 1
up{instance="10.244.0.70", job="composer-frontend"} | 1
up{instance="10.244.0.71", job="nginx"} | 1
up{instance="10.244.0.72", job="composer-backend"} | 1
up{instance="10.244.0.73", job="stage-frontend"} | 1
up{instance="10.244.0.74", job="rabbitmq"} | 1
up{instance="10.244.0.75", job="rest-service"} | 1
up{instance="10.244.0.77", job="prometheus"} | 1
up{instance="10.244.0.78", job="postgresql"} | 1
up{instance="10.244.0.79", job="stage-backend"} | 1
up{instance="10.244.0.80", job="mgmtworker"} | 1
up{instance="10.244.0.81", job="fileserver"} | 1
```