### PR TITLE
RND-297 Simplify connections inside the cluster

### DIFF
--- a/cloudify-services/templates/composer-backend.yaml
+++ b/cloudify-services/templates/composer-backend.yaml
@@ -18,7 +18,11 @@ spec:
       containers:
         - env:
             - name: RESTSERVICE_ADDRESS
-              value: {{ .Values.composer_backend.restservice_address }}
+              value: cloudify-entrypoint
+            - name: RESTSERVICE_PROTOCOL
+              value: "http://"
+            - name: RESTSERVICE_PORT
+              value: "80"
           image: {{ .Values.composer_backend.image }}
           imagePullPolicy: {{ .Values.composer_backend.imagePullPolicy }}
           name: composer-backend

--- a/cloudify-services/templates/ingress.yaml
+++ b/cloudify-services/templates/ingress.yaml
@@ -29,7 +29,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: nginx
+                name: cloudify-entrypoint
                 port:
                   number: {{ .servicePort | default $httpPort }}
 {{- end }}

--- a/cloudify-services/templates/mgmtworker.yaml
+++ b/cloudify-services/templates/mgmtworker.yaml
@@ -27,9 +27,6 @@ spec:
               python -m manager_rest.configure_manager --rabbitmq-wait rabbitmq
               python -m manager_rest.configure_manager --db-wait postgresql
               python -m manager_rest.configure_manager --create-admin-token /opt/mgmtworker/work/admin_token
-          env:
-            - name: ENTRYPOINT
-              value: nginx
           volumeMounts:
             - mountPath: /etc/cloudify/ssl
               name: ssl
@@ -40,6 +37,13 @@ spec:
         - name: mgmtworker
           image: {{ .Values.mgmtworker.image }}
           imagePullPolicy: {{ .Values.mgmtworker.imagePullPolicy }}
+          env:
+            - name: REST_HOST
+              value: cloudify-entrypoint
+            - name: REST_PORT
+              value: "80"
+            - name: REST_PROTOCOL
+              value: http
           volumeMounts:
             - mountPath: /etc/cloudify/ssl
               name: ssl

--- a/cloudify-services/templates/nginx.yaml
+++ b/cloudify-services/templates/nginx.yaml
@@ -102,7 +102,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: nginx
+  name: cloudify-entrypoint
 spec:
   ports:
     - name: http

--- a/cloudify-services/templates/stage-backend.yaml
+++ b/cloudify-services/templates/stage-backend.yaml
@@ -18,7 +18,11 @@ spec:
       containers:
         - env:
             - name: RESTSERVICE_ADDRESS
-              value: {{ .Values.stage_backend.restservice_address }}
+              value: cloudify-entrypoint
+            - name: RESTSERVICE_PROTOCOL
+              value: http
+            - name: RESTSERVICE_PORT
+              value: "80"
           image: {{ .Values.stage_backend.image }}
           imagePullPolicy: {{ .Values.stage_backend.imagePullPolicy }}
           name: stage-backend

--- a/cloudify-services/values.yaml
+++ b/cloudify-services/values.yaml
@@ -74,7 +74,6 @@ composer_backend:
   image: 263721492972.dkr.ecr.eu-west-1.amazonaws.com/cloudify-manager-composer-backend:latest-x86_64
   imagePullPolicy: IfNotPresent
   port: 3000
-  restservice_address: nginx
   probes:
     liveness:
       enabled: false
@@ -225,7 +224,6 @@ stage_backend:
   image: 263721492972.dkr.ecr.eu-west-1.amazonaws.com/cloudify-manager-stage-backend:latest-x86_64
   imagePullPolicy: IfNotPresent
   port: 8088
-  restservice_address: nginx
   probes:
     liveness:
       enabled: true


### PR DESCRIPTION
Inside of the cluster, just use 80/http. It's not guaranteed that the internal-cluster name ("nginx", or - now - "cloudify-entrypoint") is going to be on the cert. And we're going to terminate that cert on ingress anyway.