### PR TITLE
RND-322 Upload agent packages to fileserver

### DIFF
--- a/cloudify-services/templates/_helpers.tpl
+++ b/cloudify-services/templates/_helpers.tpl
@@ -91,3 +91,21 @@ cloudify_internal_key.pem: {{ $internalCert.Key | b64enc }}
 rabbitmq-cert.pem: {{ $rabbitmqCert.Cert | b64enc }}
 rabbitmq-key.pem: {{ $rabbitmqCert.Key | b64enc }}
 {{- end -}}
+
+{{/*
+Generate list of curl commands to download resources.  Argument to this function
+is a list of two elements:
+  - base directory for downloads
+  - map of destination file names to download urls
+Output is a string like:
+  curl -o /dir/f1 -L ftp://files.com/1 && curl -o /dir/f2 -L http://files.org/2
+*/}}
+{{- define "cloudify-services.curl-download" -}}
+{{- $destination := index . 0 -}}
+{{- $curls := list -}}
+{{- range $artifact, $url := (index . 1) -}}
+{{- $cmd := printf "curl -o %s/%s -L %s" $destination $artifact $url -}}
+{{- $curls = append $curls $cmd -}}
+{{- end -}}
+{{- printf (join " && " $curls ) -}}
+{{- end -}}

--- a/cloudify-services/templates/rest-service.yaml
+++ b/cloudify-services/templates/rest-service.yaml
@@ -74,6 +74,30 @@ spec:
               value: {{ .Values.fileserver.access_key }}
             - name: MINIO_SERVER_SECRET_KEY
               value: {{ .Values.fileserver.secret_key }}
+        - name: local-agent-packages-fetch
+          image: alpine/curl
+          imagePullPolicy: {{ .Values.rest_service.imagePullPolicy }}
+          args:
+            - sh
+            - -c
+            - mkdir -p /tmp/packages/agents && {{ ( include "cloudify-services.curl-download" ( list "/tmp/packages/agents" .Values.resources.packages.agents ) ) }}
+          volumeMounts:
+            - mountPath: /tmp/packages
+              name: packages
+        - name: fileserver-upload-agent-packages
+          image: {{ .Values.fileserver.client_image }}
+          imagePullPolicy: {{ .Values.rest_service.imagePullPolicy }}
+          args: [cp, --recursive, /tmp/packages/, minio/resources/packages/]
+          env:
+            - name: MINIO_SERVER_HOST
+              value: fileserver
+            - name: MINIO_SERVER_ACCESS_KEY
+              value: {{ .Values.fileserver.access_key }}
+            - name: MINIO_SERVER_SECRET_KEY
+              value: {{ .Values.fileserver.secret_key }}
+          volumeMounts:
+            - mountPath: /tmp/packages
+              name: packages
         {{ end }}
       containers:
         - name: rest-service
@@ -102,6 +126,10 @@ spec:
           secret:
             secretName: {{ template "cloudify-services.name" . }}-certs
             optional: false
+        - name: packages
+          emptyDir:
+            sizeLimit: 500Mi
+
 ---
 apiVersion: v1
 kind: Service

--- a/cloudify-services/values.yaml
+++ b/cloudify-services/values.yaml
@@ -47,7 +47,12 @@ certs:
   rabbitmq_cert: ""
   rabbitmq_key: ""
 
-resources: {}
+resources:
+  packages:
+    agents:
+      manylinux-x86_64-agent.tar.gz: https://cloudify-release-eu.s3.amazonaws.com/cloudify/7.0.0/ga-release/manylinux-x86_64-agent_7.0.0-ga.tar.gz
+      manylinux-aarch64-agent.tar.gz: https://cloudify-release-eu.s3.amazonaws.com/cloudify/7.0.0/ga-release/manylinux-aarch64-agent_7.0.0-ga.tar.gz
+      cloudify-windows-agent.exe: https://cloudify-release-eu.s3.amazonaws.com/cloudify/7.0.0/ga-release/cloudify-windows-agent_7.0.0-ga.exe
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
Three files are uploaded to /resources/packages/agents bucket/path in the cluster's fileserver pod.  Similarly to where they are stored in the all-in-one environment.