### PR TITLE
RND-584 cloudify-services: add rate-limit to the nginx dispatch

### DIFF
--- a/cloudify-services/nginx-configs/templates/default.conf.template
+++ b/cloudify-services/nginx-configs/templates/default.conf.template
@@ -32,6 +32,15 @@ upstream cloudify-api {
   server ${API_SERVICE_HOST}:${API_SERVICE_SERVICE_PORT};
 }
 
+{{ if .Values.nginx.rate_limit.enabled }}
+map $http_execution_token $no_token_limit {
+  default $binary_remote_addr;
+  "~.+" "";
+}
+
+limit_req_zone $no_token_limit zone=ratelimit:10m rate={{ .Values.nginx.rate_limit.rate }};
+{{ end }}
+
 map $http_upgrade $connection_upgrade {
   default upgrade;
   '' close;
@@ -45,6 +54,10 @@ server {
   ssl_certificate     /etc/cloudify/ssl/cloudify_external_cert.pem;
   ssl_certificate_key /etc/cloudify/ssl/cloudify_external_key.pem;
 
+  {{ if .Values.nginx.rate_limit.enabled }}
+  limit_req zone=ratelimit burst={{ .Values.nginx.rate_limit.burst }} delay={{ .Values.nginx.rate_limit.delay }};
+  {{ end }}
+
   include "/etc/nginx/conf.d/logs-conf.cloudify";
   include "/etc/nginx/conf.d/rest-location.cloudify";
   include "/etc/nginx/conf.d/fileserver.cloudify";
@@ -57,6 +70,11 @@ server {
 server {
   listen              80;
   server_name         _;
+
+  {{ if .Values.nginx.rate_limit.enabled }}
+  limit_req zone=ratelimit burst={{ .Values.nginx.rate_limit.burst }} delay={{ .Values.nginx.rate_limit.delay }};
+  {{ end }}
+
   include "/etc/nginx/conf.d/logs-conf.cloudify";
   include "/etc/nginx/conf.d/rest-location.cloudify";
   include "/etc/nginx/conf.d/fileserver.cloudify";
@@ -72,6 +90,10 @@ server {
 
   ssl_certificate     /etc/cloudify/ssl/cloudify_internal_cert.pem;
   ssl_certificate_key /etc/cloudify/ssl/cloudify_internal_key.pem;
+
+  {{ if .Values.nginx.rate_limit.enabled }}
+  limit_req zone=ratelimit burst={{ .Values.nginx.rate_limit.burst }} delay={{ .Values.nginx.rate_limit.delay }};
+  {{ end }}
 
   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 

--- a/cloudify-services/templates/nginx.yaml
+++ b/cloudify-services/templates/nginx.yaml
@@ -12,7 +12,7 @@ kind: ConfigMap
 metadata:
   name: nginx-templates
 data:
-{{ (.Files.Glob "nginx-configs/templates/*").AsConfig | indent 2 }}
+{{ (tpl (.Files.Glob "nginx-configs/templates/*").AsConfig .) | indent 2 }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/cloudify-services/values.yaml
+++ b/cloudify-services/values.yaml
@@ -121,6 +121,23 @@ nginx:
       timeoutSeconds: 10
       successThreshold: 1
       failureThreshold: 3
+  # configure request rate-limits. If enabled, requests are rate-limited based
+  # on the remote IP address.
+  # Requests that authenticate with a valid execution-token, are never
+  # rate-limited
+  rate_limit:
+    enabled: true
+    # rate is a string in the form of "10r/s" (10 requests per second)
+    # or "600r/m" (600 requests per minute)
+    rate: "10r/s"
+    # burst and delay manage the request queueing mechanism. With the
+    # default settings of burst=30 and delay=20, up to 30 requests
+    # can be queued per IP (i.e. before nginx starts responding with 503),
+    # and the first 20 requests will be served without any delay. Then, requests
+    # will be delayed according to the rate, and if there's more than 30 queued
+    # total, will receive 503.
+    burst: 30
+    delay: 20
 
 postgresql:
   replicas: 1


### PR DESCRIPTION
Similar to cloudify-cosmo/cloudify-manager-install#1520 add a basic rate-limiting mechanism.

Note: in order to achieve the `if`, nginx configs now need to be templated via helm (with `tpl`)