### PR TITLE
Declare dockerhub image links

### DIFF
--- a/cloudify-services/dockerhub-values.yaml
+++ b/cloudify-services/dockerhub-values.yaml
@@ -1,0 +1,29 @@
+# use these value overrides, to run the cloudify-services chart
+# using images published to dockerhub
+
+composer_backend:
+  image: docker.io/cloudifyplatform/cloudify-manager-composer-backend:7.0.2
+
+composer_frontend:
+  image: docker.io/cloudifyplatform/cloudify-manager-composer-frontend:7.0.2
+
+execution_scheduler:
+  image: docker.io/cloudifyplatform/cloudify-manager-execution-scheduler:7.0.2
+
+mgmtworker:
+  image: docker.io/cloudifyplatform/cloudify-manager-mgmtworker:7.0.2
+
+rabbitmq:
+  image: docker.io/cloudifyplatform/cloudify-manager-rabbitmq:7.0.2
+
+rest_service:
+  image: docker.io/cloudifyplatform/cloudify-manager-restservice:7.0.2
+
+api_service:
+  image: docker.io/cloudifyplatform/cloudify-manager-apiservice:7.0.2
+
+stage_backend:
+  image: docker.io/cloudifyplatform/cloudify-manager-stage-backend:7.0.2
+
+stage_frontend:
+  image: docker.io/cloudifyplatform/cloudify-manager-stage-frontend:7.0.2


### PR DESCRIPTION
Use these value overrides, to run the cloudify-services chart using images published to dockerhub.