### PR TITLE
RND-1261 Don't break when agent urls are set to null

### DIFF
--- a/cloudify-services/templates/rest-service.yaml
+++ b/cloudify-services/templates/rest-service.yaml
@@ -76,6 +76,7 @@ spec:
             limits:
               memory: 100Mi
               cpu: 0.5
+        {{ if ((.Values.resources).packages).agents }}
         - name: local-agent-packages-fetch
           image: alpine/curl
           imagePullPolicy: {{ .Values.rest_service.imagePullPolicy }}
@@ -142,6 +143,7 @@ spec:
             limits:
               memory: 100Mi
               cpu: 0.5
+        {{ end }}
         {{ end }}
       containers:
         - name: rest-service


### PR DESCRIPTION
If the users sets resources.packages.agents to null, the `curl` loop would break, because we'd leave only a `&&` rendered, and that's a bash syntax error.

Instead, let's just not run those containers at all, they're not needed.

Wrap the `if` expression in parens so that nulling at any level is valid, e.g. `resources: null`