### PR TITLE
worker chart: "no UI" build compat

### DIFF
--- a/cloudify-manager-worker/README.md
+++ b/cloudify-manager-worker/README.md
@@ -482,6 +482,8 @@ $ helm install cloudify-manager-worker cloudify-helm/cloudify-manager-worker --v
 | db.serverUsername | string | `"postgres"` | Username for initial DB connection |
 | db.useExternalDB | bool | `false` | When switched to true, it will take the FQDN for the pgsql database in host, and require CA cert in secret inputs under TLS section |
 | fullnameOverride | string | `"cloudify-manager-worker"` |  |
+| hotfix | object | `{"rnd1267":true}` | Parameters group for enabling hotfixes/patches for various issues |
+| hotfix.rnd1267 | bool | `true` | Hotfix for RND-1267: in the 7.0.x branch, on some k8s setups, the manager can't be installed and throws a "/tmp/tmp<random> is not a directory". If that happens, make sure this is enabled.) |
 | image | object | object | Parameters group for Docker images |
 | image.pullPolicy | string | `"IfNotPresent"` | Specify a imagePullPolicy, Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'. ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images |
 | image.pullSecrets | list | `[]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |

--- a/cloudify-manager-worker/templates/after_hook.yaml
+++ b/cloudify-manager-worker/templates/after_hook.yaml
@@ -54,45 +54,63 @@ data:
         echo "Copy necessary files to Persistent Volume"
         cp -a --verbose /opt/mgmtworker/work/admin_token $CLOUDIFY_DATA_DIR/mgmtworker
         cp -a --verbose /opt/manager/rest-security.conf $CLOUDIFY_DATA_DIR/manager
-        cp -a --verbose /opt/cloudify-composer/backend/conf/prod.json $CLOUDIFY_DATA_DIR/cloudify-composer
-        cp -a --verbose /opt/cloudify-composer/backend/conf/db_ca.crt $CLOUDIFY_DATA_DIR/cloudify-composer
-        cp -a --verbose /opt/cloudify-stage/conf/db_ca.crt $CLOUDIFY_DATA_DIR/cloudify-stage
-        cp -a --verbose /opt/cloudify-stage/conf/manager.json $CLOUDIFY_DATA_DIR/cloudify-stage
+        if [ -d "/opt/cloudify-composer" ]; then
+          cp -a --verbose /opt/cloudify-composer/backend/conf/prod.json $CLOUDIFY_DATA_DIR/cloudify-composer
+          cp -a --verbose /opt/cloudify-composer/backend/conf/db_ca.crt $CLOUDIFY_DATA_DIR/cloudify-composer
+        fi
+        if [ -d "/opt/cloudify-stage" ]; then
+          cp -a --verbose /opt/cloudify-stage/conf/db_ca.crt $CLOUDIFY_DATA_DIR/cloudify-stage
+          cp -a --verbose /opt/cloudify-stage/conf/manager.json $CLOUDIFY_DATA_DIR/cloudify-stage
+        fi
 
         echo "Copy necessary directories to Persistent Volume"
         cp -a --verbose /opt/manager/resources $CLOUDIFY_DATA_DIR/manager
         cp -a --verbose /opt/mgmtworker/env/plugins $CLOUDIFY_DATA_DIR/mgmtworker
-        cp -a --verbose /opt/cloudify-stage/dist/userData $CLOUDIFY_DATA_DIR/cloudify-stage
+        if [ -d "/opt/cloudify-stage" ]; then
+          cp -a --verbose /opt/cloudify-stage/dist/userData $CLOUDIFY_DATA_DIR/cloudify-stage
+        fi
         
         touch "$CLOUDIFY_DATA_DIR/init-completed"
 
         echo "Removed unused directory"
         rm -rf --verbose /opt/manager/resources
         rm -rf --verbose /opt/mgmtworker/env/plugins
-        rm -rf --verbose /opt/cloudify-stage/dist/userData
+        if [ -d "/opt/cloudify-stage" ]; then
+          rm -rf --verbose /opt/cloudify-stage/dist/userData
+        fi
 
         echo "Removed unused files"
         rm -f --verbose /opt/mgmtworker/work/admin_token
 
         rm -f --verbose /opt/manager/rest-security.conf
-        rm -f --verbose /opt/cloudify-composer/backend/conf/prod.json
-        rm -f --verbose /opt/cloudify-composer/backend/conf/db_ca.crt
-        rm -f --verbose /opt/cloudify-stage/conf/db_ca.crt
-        rm -f --verbose /opt/cloudify-stage/conf/manager.json
+        if [ -d "/opt/cloudify-composer" ]; then
+          rm -f --verbose /opt/cloudify-composer/backend/conf/prod.json
+          rm -f --verbose /opt/cloudify-composer/backend/conf/db_ca.crt
+        fi
+        if [ -d "/opt/cloudify-stage" ]; then
+          rm -f --verbose /opt/cloudify-stage/conf/db_ca.crt
+          rm -f --verbose /opt/cloudify-stage/conf/manager.json
+        fi
 
         echo "Making symbolic links for directory"
         ln -s --verbose "$CLOUDIFY_DATA_DIR/manager/resources" /opt/manager/resources
         ln -s --verbose "$CLOUDIFY_DATA_DIR/mgmtworker/plugins" /opt/mgmtworker/env/plugins
-        ln -s --verbose "$CLOUDIFY_DATA_DIR/cloudify-stage/userData" /opt/cloudify-stage/dist/userData
+        if [ -d "/opt/cloudify-stage" ]; then
+          ln -s --verbose "$CLOUDIFY_DATA_DIR/cloudify-stage/userData" /opt/cloudify-stage/dist/userData
+        fi
 
         echo "Making symbolic links for files"
         ln -s --verbose "$CLOUDIFY_DATA_DIR/mgmtworker/admin_token" /opt/mgmtworker/work/admin_token
 
         ln -s --verbose "$CLOUDIFY_DATA_DIR/manager/rest-security.conf" /opt/manager/rest-security.conf
-        ln -s --verbose "$CLOUDIFY_DATA_DIR/cloudify-composer/prod.json" /opt/cloudify-composer/backend/conf/prod.json
-        ln -s --verbose "$CLOUDIFY_DATA_DIR/cloudify-composer/db_ca.crt" /opt/cloudify-composer/backend/conf/db_ca.crt
-        ln -s --verbose "$CLOUDIFY_DATA_DIR/cloudify-stage/db_ca.crt" /opt/cloudify-stage/conf/db_ca.crt
-        ln -s --verbose "$CLOUDIFY_DATA_DIR/cloudify-stage/manager.json" /opt/cloudify-stage/conf/manager.json
+        if [ -d "/opt/cloudify-composer" ]; then
+          ln -s --verbose "$CLOUDIFY_DATA_DIR/cloudify-composer/prod.json" /opt/cloudify-composer/backend/conf/prod.json
+          ln -s --verbose "$CLOUDIFY_DATA_DIR/cloudify-composer/db_ca.crt" /opt/cloudify-composer/backend/conf/db_ca.crt
+        fi
+        if [ -d "/opt/cloudify-composer" ]; then
+          ln -s --verbose "$CLOUDIFY_DATA_DIR/cloudify-stage/db_ca.crt" /opt/cloudify-stage/conf/db_ca.crt
+          ln -s --verbose "$CLOUDIFY_DATA_DIR/cloudify-stage/manager.json" /opt/cloudify-stage/conf/manager.json
+        fi
 
         # Version-specific operations
         case ${WORKER_VERSION[0]} in

--- a/cloudify-manager-worker/templates/before_hook.yaml
+++ b/cloudify-manager-worker/templates/before_hook.yaml
@@ -32,16 +32,21 @@ data:
 
     mkdir -p /mnt/cloudify-data/manager
     mkdir -p /mnt/cloudify-data/mgmtworker
-    mkdir -p /mnt/cloudify-data/cloudify-composer
-    mkdir -p /mnt/cloudify-data/cloudify-stage
     mkdir -p /mnt/cloudify-data/latest
+    if [ -d "/opt/cloudify-composer" ]; then
+      mkdir -p /mnt/cloudify-data/cloudify-composer
+    fi
 
     echo "Creating symbolic link for configs"
     rm -f --verbose /etc/cloudify/config.yaml
     ln -s --verbose "$CLOUDIFY_DATA_DIR/etc/config.yaml" /etc/cloudify/config.yaml
     chown cfyuser "$CLOUDIFY_DATA_DIR/etc/config.yaml"
-    rm -f --verbose /opt/cloudify-stage/conf/userConfig.json
-    ln -s --verbose "$CLOUDIFY_DATA_DIR/cloudify-stage/userConfig.json" /opt/cloudify-stage/conf/userConfig.json
+
+    if [ -d "/opt/cloudify-stage" ]; then
+      mkdir -p /mnt/cloudify-data/cloudify-stage
+      rm -f --verbose /opt/cloudify-stage/conf/userConfig.json
+      ln -s --verbose "$CLOUDIFY_DATA_DIR/cloudify-stage/userConfig.json" /opt/cloudify-stage/conf/userConfig.json
+    fi
 
     if [ -f "$FILE" ]; then
       echo "The Data exists on PV - creating symbolic links to files and folders on PV"
@@ -63,27 +68,41 @@ data:
       echo "Remove unused files"
       rm -f --verbose /opt/mgmtworker/work/admin_token
       rm -f --verbose /opt/manager/rest-security.conf
-      rm -f --verbose /opt/cloudify-composer/backend/conf/prod.json
-      rm -f --verbose /opt/cloudify-composer/backend/conf/db_ca.crt
-      rm -f --verbose /opt/cloudify-stage/conf/db_ca.crt
-      rm -f --verbose /opt/cloudify-stage/conf/manager.json
+      if [ -d "/opt/cloudify-composer" ]; then
+        rm -f --verbose /opt/cloudify-composer/backend/conf/prod.json
+        rm -f --verbose /opt/cloudify-composer/backend/conf/db_ca.crt
+      fi
+      if [ -d "/opt/cloudify-stage" ]; then
+        rm -f --verbose /opt/cloudify-stage/conf/db_ca.crt
+        rm -f --verbose /opt/cloudify-stage/conf/manager.json
+      fi
 
       echo "Making symbolic links for files"
       ln -s --verbose "$CLOUDIFY_DATA_DIR/mgmtworker/admin_token" /opt/mgmtworker/work/admin_token
       ln -s --verbose "$CLOUDIFY_DATA_DIR/manager/rest-security.conf" /opt/manager/rest-security.conf
-      ln -s --verbose "$CLOUDIFY_DATA_DIR/cloudify-composer/prod.json" /opt/cloudify-composer/backend/conf/prod.json
-      ln -s --verbose "$CLOUDIFY_DATA_DIR/cloudify-composer/db_ca.crt" /opt/cloudify-composer/backend/conf/db_ca.crt
-      ln -s --verbose "$CLOUDIFY_DATA_DIR/cloudify-stage/db_ca.crt" /opt/cloudify-stage/conf/db_ca.crt
-      ln -s --verbose "$CLOUDIFY_DATA_DIR/cloudify-stage/manager.json" /opt/cloudify-stage/conf/manager.json
+      if [ -d "/opt/cloudify-composer" ]; then
+        ln -s --verbose "$CLOUDIFY_DATA_DIR/cloudify-composer/prod.json" /opt/cloudify-composer/backend/conf/prod.json
+        ln -s --verbose "$CLOUDIFY_DATA_DIR/cloudify-composer/db_ca.crt" /opt/cloudify-composer/backend/conf/db_ca.crt
+      fi
+      if [ -d "/opt/cloudify-stage" ]; then
+        ln -s --verbose "$CLOUDIFY_DATA_DIR/cloudify-stage/db_ca.crt" /opt/cloudify-stage/conf/db_ca.crt
+        ln -s --verbose "$CLOUDIFY_DATA_DIR/cloudify-stage/manager.json" /opt/cloudify-stage/conf/manager.json
+      fi
 
       echo "Making symbolic links for directory"
       ln -s --verbose "$CLOUDIFY_DATA_DIR/manager/resources" /opt/manager/resources
       ln -s --verbose "$CLOUDIFY_DATA_DIR/mgmtworker/plugins" /opt/mgmtworker/env/plugins
-      ln -s --verbose "$CLOUDIFY_DATA_DIR/cloudify-stage/userData" /opt/cloudify-stage/dist/userData
+      if [ -d "/opt/cloudify-stage" ]; then
+        ln -s --verbose "$CLOUDIFY_DATA_DIR/cloudify-stage/userData" /opt/cloudify-stage/dist/userData
+      fi
 
       echo "Set proper permissions for stage/composer files"
-      chown composer_user /opt/cloudify-composer/backend/conf/prod.json
-      chown stage_user /opt/cloudify-stage/conf/manager.json
+      if [ -d "/opt/cloudify-composer" ]; then
+        chown composer_user /opt/cloudify-composer/backend/conf/prod.json
+      fi
+      if [ -d "/opt/cloudify-stage" ]; then
+        chown stage_user /opt/cloudify-stage/conf/manager.json
+      fi
 
       # Version-specific operations
       case ${WORKER_VERSION[0]} in

--- a/cloudify-manager-worker/templates/cfy-log-monitor.yaml
+++ b/cloudify-manager-worker/templates/cfy-log-monitor.yaml
@@ -12,17 +12,19 @@ data:
     
     ( umask 0 && truncate -s0 $LOGS/manager/cfy_manager.log )
     ( umask 0 && truncate -s0 $LOGS/amqp-postgres/amqp_postgres.log )
-    ( umask 0 && truncate -s0 $LOGS/composer/{app,errors}.log )
     ( umask 0 && truncate -s0 $LOGS/execution-scheduler/schedule r.log )
     ( umask 0 && truncate -s0 $LOGS/mgmtworker/mgmtworker.log )
     ( umask 0 && truncate -s0 $LOGS/nginx/{cloudify.access,access,cloudify.error,error,monitoring.access,monitoring.error}.log )
     ( umask 0 && truncate -s0 $LOGS/rest/{api-audit,api-gunicorn,audit,cloudify-rest-service,cloudify-api-service,gunicorn}.log )
-    ( umask 0 && truncate -s0 $LOGS/stage/server-{error,output}.log )
+    if [ -d "/opt/cloudify-composer" ]; then
+      ( umask 0 && truncate -s0 $LOGS/composer/{app,errors}.log )
+    fi
+    if [ -d "/opt/cloudify-stage" ]; then
+      ( umask 0 && truncate -s0 $LOGS/stage/server-{error,output}.log )
+    fi
 
     tail -F --quiet $LOGS/manager/cfy_manager.log | sed "s|^|cfy_manager.log: |" & \
-    tail -F --quiet $LOGS/amqp-postgres/amqp_postgres.log | sed "s|^|amqp_postgres.log: |" &  \
-    tail -F --quiet $LOGS/composer/app.log | sed "s|^|app.log: |" & \
-    tail -F --quiet $LOGS/composer/errors.log | sed "s|^|errors.log: |" & \
+    tail -F --quiet $LOGS/amqp-postgres/amqp_postgres.log | sed "s|^|amqp_postgres.log: |" & \
     tail -F --quiet $LOGS/execution-scheduler/scheduler.log  | sed "s|^|scheduler.log: |" & \
     tail -F --quiet $LOGS/mgmtworker/mgmtworker.log  | sed "s|^|mgmtworker.log: |" & \
     tail -F --quiet $LOGS/nginx/cloudify.access.log | sed "s|^|cloudify.access.log: |" & \
@@ -37,6 +39,11 @@ data:
     tail -F --quiet $LOGS/rest/cloudify-rest-service.log | sed "s|^|cloudify-rest-service.log: |" & \
     tail -F --quiet $LOGS/rest/cloudify-api-service.log | sed "s|^|cloudify-api-service.log: |" & \
     tail -F --quiet $LOGS/rest/gunicorn.log | sed "s|^|gunicorn.log: |" & \
-    tail -F --quiet $LOGS/stage/server-error.log | sed "s|^|server-errors.log: |" & \
-    tail -F --quiet $LOGS/stage/server-output.log | sed "s|^|server-output.log: |"
-
+    if [ -d "/opt/cloudify-composer" ]; then
+      tail -F --quiet $LOGS/composer/app.log | sed "s|^|app.log: |" &
+      tail -F --quiet $LOGS/composer/errors.log | sed "s|^|errors.log: |" &
+    fi
+    if [ -d "/opt/cloudify-stage" ]; then
+      tail -F --quiet $LOGS/stage/server-error.log | sed "s|^|server-errors.log: |" &
+      tail -F --quiet $LOGS/stage/server-output.log | sed "s|^|server-output.log: |"
+    fi

--- a/cloudify-manager-worker/templates/cfy-starter.yaml
+++ b/cloudify-manager-worker/templates/cfy-starter.yaml
@@ -19,6 +19,9 @@ data:
       touch /tmp/before_hook_completed
     fi
 
+    {{ if (.Values.hotfix).rnd1267 }}
+    sed -ie 's|if os.path.ismount(path)|if os.path.isdir(path) and os.path.ismount(path)|' /opt/cloudify/cfy_manager/lib/python3.11/site-packages/cfy_manager/utils/files.py
+    {{ end }}
     echo 'Run cloudify manager'
     /usr/bin/cfy_manager image-starter
 

--- a/cloudify-manager-worker/values.yaml
+++ b/cloudify-manager-worker/values.yaml
@@ -489,6 +489,8 @@ mainConfig: |
   composer:
     # If set to true, Cloudify Composer will not be installed
     skip_installation: false
+  stage:
+    skip_installation: false
   restservice:
     gunicorn:
       worker_count: {{ .Values.config.workerCount }}
@@ -717,3 +719,10 @@ postgresql:
   metrics:
     image:
       tag: 0.8.0-debian-10-r278
+
+# -- Parameters group for enabling hotfixes/patches for various issues
+hotfix:
+  # -- Hotfix for RND-1267: in the 7.0.x branch, on some k8s setups, the manager
+  # can't be installed and throws a "/tmp/tmp<random> is not a directory".
+  # If that happens, make sure this is enabled.)
+  rnd1267: true


### PR DESCRIPTION
This ports #113 to 7.0.2-build

* Make all UI files conditional

Now that UI can be missing, those files won't always be there. Every access should be conditional.
If the directory exists, we can safely assume we're running a build with the UI present.

* RND-1267 Add a hotfix

This can't be fixed in the source without a completely new build, and cannot be fixed for 7.0.1/7.0.2 at all, so it'll just need to be hotfixed here.
This presumably depends on the k8s setup you're running, but it does happen on mine.

* mainCOnfig: add the `stage` clause by default