### PR TITLE
log-monitor: make the _last_ entry nonconditional

### DIFF
--- a/cloudify-manager-worker/templates/cfy-log-monitor.yaml
+++ b/cloudify-manager-worker/templates/cfy-log-monitor.yaml
@@ -23,27 +23,27 @@ data:
       ( umask 0 && truncate -s0 $LOGS/stage/server-{error,output}.log )
     fi
 
-    tail -F --quiet $LOGS/manager/cfy_manager.log | sed "s|^|cfy_manager.log: |" & \
-    tail -F --quiet $LOGS/amqp-postgres/amqp_postgres.log | sed "s|^|amqp_postgres.log: |" & \
-    tail -F --quiet $LOGS/execution-scheduler/scheduler.log  | sed "s|^|scheduler.log: |" & \
-    tail -F --quiet $LOGS/mgmtworker/mgmtworker.log  | sed "s|^|mgmtworker.log: |" & \
-    tail -F --quiet $LOGS/nginx/cloudify.access.log | sed "s|^|cloudify.access.log: |" & \
-    tail -F --quiet $LOGS/nginx/access.log | sed "s|^|access.log: |" & \
-    tail -F --quiet $LOGS/nginx/cloudify.error.log | sed "s|^|cloudify.error.log: |" & \
-    tail -F --quiet $LOGS/nginx/error.log | sed "s|^|errors.log: |" & \
-    tail -F --quiet $LOGS/nginx/monitoring.access.log | sed "s|^|monitoring.access.log: |" & \
-    tail -F --quiet $LOGS/nginx/monitoring.error.log | sed "s|^|monitoring.error.log: |" & \
-    tail -F --quiet $LOGS/rest/api-audit.log | sed "s|^|api-audit.log: |" & \
-    tail -F --quiet $LOGS/rest/api-gunicorn.log | sed "s|^|api-gunicorn.log: |" & \
-    tail -F --quiet $LOGS/rest/audit.log | sed "s|^|audit.log: |" & \
-    tail -F --quiet $LOGS/rest/cloudify-rest-service.log | sed "s|^|cloudify-rest-service.log: |" & \
-    tail -F --quiet $LOGS/rest/cloudify-api-service.log | sed "s|^|cloudify-api-service.log: |" & \
-    tail -F --quiet $LOGS/rest/gunicorn.log | sed "s|^|gunicorn.log: |" & \
+    tail -F --quiet $LOGS/manager/cfy_manager.log | sed "s|^|cfy_manager.log: |" &
+    tail -F --quiet $LOGS/amqp-postgres/amqp_postgres.log | sed "s|^|amqp_postgres.log: |" &
+    tail -F --quiet $LOGS/execution-scheduler/scheduler.log  | sed "s|^|scheduler.log: |" &
+    tail -F --quiet $LOGS/mgmtworker/mgmtworker.log  | sed "s|^|mgmtworker.log: |" &
+    tail -F --quiet $LOGS/nginx/cloudify.access.log | sed "s|^|cloudify.access.log: |" &
+    tail -F --quiet $LOGS/nginx/access.log | sed "s|^|access.log: |" &
+    tail -F --quiet $LOGS/nginx/cloudify.error.log | sed "s|^|cloudify.error.log: |" &
+    tail -F --quiet $LOGS/nginx/error.log | sed "s|^|errors.log: |" &
+    tail -F --quiet $LOGS/nginx/monitoring.access.log | sed "s|^|monitoring.access.log: |" &
+    tail -F --quiet $LOGS/nginx/monitoring.error.log | sed "s|^|monitoring.error.log: |" &
+    tail -F --quiet $LOGS/rest/api-audit.log | sed "s|^|api-audit.log: |" &
+    tail -F --quiet $LOGS/rest/api-gunicorn.log | sed "s|^|api-gunicorn.log: |" &
+    tail -F --quiet $LOGS/rest/audit.log | sed "s|^|audit.log: |" &
+    tail -F --quiet $LOGS/rest/cloudify-rest-service.log | sed "s|^|cloudify-rest-service.log: |" &
+    tail -F --quiet $LOGS/rest/cloudify-api-service.log | sed "s|^|cloudify-api-service.log: |" &
     if [ -d "/opt/cloudify-composer" ]; then
       tail -F --quiet $LOGS/composer/app.log | sed "s|^|app.log: |" &
       tail -F --quiet $LOGS/composer/errors.log | sed "s|^|errors.log: |" &
     fi
     if [ -d "/opt/cloudify-stage" ]; then
       tail -F --quiet $LOGS/stage/server-error.log | sed "s|^|server-errors.log: |" &
-      tail -F --quiet $LOGS/stage/server-output.log | sed "s|^|server-output.log: |"
+      tail -F --quiet $LOGS/stage/server-output.log | sed "s|^|server-output.log: |" &
     fi
+    tail -F --quiet $LOGS/rest/gunicorn.log | sed "s|^|gunicorn.log: |"


### PR DESCRIPTION
All the lines here have `&`, except the last one, which keeps the bash process form exiting. So the last one must be non-conditional.

Also, remove the unnecessary `\`