### PR TITLE
CYBL-2091 Pass RUNTIME_ENVIRONMENT=k8s to rest-service

### DIFF
--- a/cloudify-services/templates/rest-service.yaml
+++ b/cloudify-services/templates/rest-service.yaml
@@ -167,6 +167,8 @@ spec:
                   name: {{ .Values.rest_service.s3.session_token_secret_name }}
                   key: session_token
             {{- end }}
+            - name: RUNTIME_ENVIRONMENT
+              value: "k8s"
           securityContext:
             allowPrivilegeEscalation: false
             runAsNonRoot: true


### PR DESCRIPTION
This enables a different method of reporting cluster's status

See https://github.com/cloudify-cosmo/cloudify-manager/pull/4319