### PR TITLE
Customization to PVC and seaweed

### DIFF
--- a/cloudify-services/templates/pvc.yaml
+++ b/cloudify-services/templates/pvc.yaml
@@ -3,8 +3,8 @@ kind: PersistentVolumeClaim
 metadata:
   name: fileserver-data
 spec:
-  accessModes:
-    - ReadWriteOnce
+  accessModes: {{ .Values.pvc.accessModes }}
+  storageClassName: {{ .Values.pvc.storageClassName }}
   resources:
     requests:
       storage: 100Mi

--- a/cloudify-services/templates/rest-service.yaml
+++ b/cloudify-services/templates/rest-service.yaml
@@ -63,7 +63,6 @@ spec:
             runAsNonRoot: true
             runAsUser: 1000
             runAsGroup: 1000
-            fsGroup: 1000
             seccompProfile:
               type: RuntimeDefault
             capabilities:
@@ -89,7 +88,6 @@ spec:
             runAsNonRoot: true
             runAsUser: 1000
             runAsGroup: 1000
-            fsGroup: 1000
             seccompProfile:
               type: RuntimeDefault
             capabilities:
@@ -114,7 +112,6 @@ spec:
             runAsNonRoot: true
             runAsUser: 1000
             runAsGroup: 1000
-            fsGroup: 1000
             seccompProfile:
               type: RuntimeDefault
             capabilities:

--- a/cloudify-services/values.yaml
+++ b/cloudify-services/values.yaml
@@ -130,6 +130,12 @@ postgresql:
       successThreshold: 1
       failureThreshold: 3
 
+pvc:
+  storageClassName: ""
+  accessModes: 
+    - ReadWriteOnce
+
+
 rabbitmq:
   replicas: 1
   image: 263721492972.dkr.ecr.eu-west-1.amazonaws.com/cloudify-manager-rabbitmq:latest-x86_64
@@ -244,6 +250,13 @@ seaweedfs:
     data:
       type: "persistentVolumeClaim"
       size: "1Gi"
+      storageClass: ""
+      hostPathPrefix: ""
+    logs:
+      type: "hostPath"
+      size: ""
+      hostPathPrefix: /var/log
+      storageClass: ""
     affinity: ""
     nodeSelector: ""
   filer:
@@ -257,6 +270,13 @@ seaweedfs:
     data:
       type: "persistentVolumeClaim"
       size: "1Gi"
+      hostPathPrefix: /var/log
+      storageClass: ""
+    logs:
+      type: "hostPath"
+      size: ""
+      hostPathPrefix: /var/log
+      storageClass: ""
     affinity: ""
     nodeSelector: ""
   s3:
@@ -271,6 +291,11 @@ seaweedfs:
       limits:
         memory: 512Mi
         cpu: 0.5
+    logs:
+      type: "hostPath"
+      size: ""
+      storageClass: ""
+      hostPathPrefix: /var/log
     affinity: ""
     nodeSelector: ""
   volume:
@@ -285,8 +310,17 @@ seaweedfs:
     data:
       type: "persistentVolumeClaim"
       size: "10Gi"
+      hostPathPrefix: /var/log
+      storageClass: ""
+    logs:
+      type: "hostPath"
+      size: ""
+      hostPathPrefix: /var/log
+      storageClass: ""
+    idx:
+      type: "hostPath"
+      size: ""
+      hostPathPrefix: ""
+      storageClass: ""
     affinity: ""
     nodeSelector: ""
-  # -- Parameters group for awscli containers (using as init containers)
-  # @default -- object
-  clientImage: docker.io/amazon/aws-cli:2.13.9

--- a/cloudify-services/values.yaml
+++ b/cloudify-services/values.yaml
@@ -324,3 +324,6 @@ seaweedfs:
       storageClass: ""
     affinity: ""
     nodeSelector: ""
+  # -- Parameters group for awscli containers (using as init containers)
+  # @default -- object
+  clientImage: docker.io/amazon/aws-cli:2.13.9


### PR DESCRIPTION
With this PR, the idea is to allow anyone using this to customize both PVC values, and seaweedFS.

In PVC, I added the option to customize accessModes and storageClassName. To change those values, simply change them in values.yaml under pvc.

In seaweed, the customization adds all four fields under data and logs, so users can change type, size, hostPathPrefix and storageClass.

I also removed fsGroup, since it seems to not be needed and was causing issues in most of the systems I tested with.