### PR TITLE
nginx config updates for proxying and downloads

### DIFF
--- a/cloudify-services/nginx-configs/templates/fileserver.cloudify.template
+++ b/cloudify-services/nginx-configs/templates/fileserver.cloudify.template
@@ -23,5 +23,11 @@ location /resources-s3 {
 
     resolver kube-dns.kube-system.svc.cluster.local;
     set $resource_url $upstream_http_x_s3_uri;
+
+    # hide content-disposition coming from the s3 backend, because the
+    # restservice already sets it, with the correct filename
+    # (e.g. based on the blueprint id)
+    proxy_hide_header Content-Disposition;
+
     proxy_pass $resource_url;
 }

--- a/cloudify-services/nginx-configs/templates/rest-proxy.cloudify.template
+++ b/cloudify-services/nginx-configs/templates/rest-proxy.cloudify.template
@@ -1,11 +1,15 @@
     proxy_pass         http://cloudify-rest;
     proxy_redirect     off;
+    proxy_buffering    off;
+    proxy_http_version 1.1;
 
     proxy_set_header   Host              $host;
     proxy_set_header   X-Real-IP         $remote_addr;
     proxy_set_header   X-Server-Port     $server_port;
     proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
     proxy_set_header   X-Forwarded-Proto $scheme;
+    proxy_set_header   Upgrade           $http_upgrade;
+    proxy_set_header   Connection        $connection_upgrade;
 
     proxy_hide_header  X-Cloudify-Audit-Auth-Method;
     proxy_hide_header  X-Cloudify-Audit-Tenant;


### PR DESCRIPTION
This ports #119 to 7.0.3

* NE-7550 nginx: hide duplicated content-disposition header

* nginx proxy settings: use http/1.1

Several useful settings for nginx proxying:
- use http/1.1
- other headers which are going to be necessary for things like websockets, but are good to have anyway