### PR TITLE
NE-7793 Mgmworker RUNTIME_ENVIRONMENT envvar

### DIFF
--- a/cloudify-services/templates/_helpers.tpl
+++ b/cloudify-services/templates/_helpers.tpl
@@ -70,15 +70,15 @@ Generate certificates for cloudify-services
 {{- if and (.Values.certs.ca_cert) (.Values.certs.ca_key) }}
 {{- $ca = buildCustomCert .Values.certs.ca_cert .Values.certs.ca_key }}
 {{- end }}
-{{- $externalCert := genSignedCert "nginx" nil nil 3650 $ca -}}
+{{- $externalCert := genSignedCert "nginx" nil (list "nginx") 3650 $ca -}}
 {{- if and (.Values.certs.external_cert) (.Values.certs.external_key) }}
 {{- $externalCert = buildCustomCert .Values.certs.external_cert .Values.certs.external_key }}
 {{- end }}
-{{- $internalCert := genSignedCert "nginx" nil nil 3650 $ca -}}
+{{- $internalCert := genSignedCert "nginx" nil (list "nginx") 3650 $ca -}}
 {{- if and (.Values.certs.internal_cert) (.Values.certs.internal_key) }}
 {{- $internalCert = buildCustomCert .Values.certs.internal_cert .Values.certs.internal_key }}
 {{- end }}
-{{- $rabbitmqCert := genSignedCert "rabbitmq" nil nil 3650 $ca -}}
+{{- $rabbitmqCert := genSignedCert "rabbitmq" nil (list "rabbitmq") 3650 $ca -}}
 {{- if and (.Values.certs.rabbitmq_cert) (.Values.certs.rabbitmq_key) }}
 {{- $rabbitmqCert = buildCustomCert .Values.certs.rabbitmq_cert .Values.certs.rabbitmq_key }}
 {{- end }}

--- a/cloudify-services/templates/mgmtworker.yaml
+++ b/cloudify-services/templates/mgmtworker.yaml
@@ -93,6 +93,9 @@ spec:
                 - ALL
               add:
                 - NET_BIND_SERVICE
+          env:
+            - name: RUNTIME_ENVIRONMENT
+              value: "k8s"
           envFrom:
             - configMapRef:
                 name: mgmtworker-envvars


### PR DESCRIPTION
* Add RUNTIME_ENVIRONMENT envvar to mgmtworker
  It is used to determine the version of `fetch-logs` script to be run: 
  either the one working with all-in-one (a.k.a. single-node) installation
  or Cloudify cluster installation, or Kubernetes-based installation.

* Backport of https://github.com/fusion-e/fusion-helm/pull/87

This is a cherry-pick of #122 