### PR TITLE
NE-7791 Compatibility with replicated postgresql

### DIFF
--- a/cloudify-services/templates/_helpers.tpl
+++ b/cloudify-services/templates/_helpers.tpl
@@ -70,11 +70,11 @@ Generate certificates for cloudify-services
 {{- if and (.Values.certs.ca_cert) (.Values.certs.ca_key) }}
 {{- $ca = buildCustomCert .Values.certs.ca_cert .Values.certs.ca_key }}
 {{- end }}
-{{- $externalCert := genSignedCert "nginx" nil (list "nginx") 3650 $ca -}}
+{{- $externalCert := genSignedCert "nginx" nil (list "nginx" "cloudify-entrypoint") 3650 $ca -}}
 {{- if and (.Values.certs.external_cert) (.Values.certs.external_key) }}
 {{- $externalCert = buildCustomCert .Values.certs.external_cert .Values.certs.external_key }}
 {{- end }}
-{{- $internalCert := genSignedCert "nginx" nil (list "nginx") 3650 $ca -}}
+{{- $internalCert := genSignedCert "nginx" nil (list "nginx" "cloudify-entrypoint") 3650 $ca -}}
 {{- if and (.Values.certs.internal_cert) (.Values.certs.internal_key) }}
 {{- $internalCert = buildCustomCert .Values.certs.internal_cert .Values.certs.internal_key }}
 {{- end }}

--- a/cloudify-services/templates/_helpers.tpl
+++ b/cloudify-services/templates/_helpers.tpl
@@ -109,3 +109,21 @@ Output is a string like:
 {{- end -}}
 {{- printf (join " && " $curls ) -}}
 {{- end -}}
+
+
+{{/*
+Return env vars block with postgresql connection parameters.
+*/}}
+{{- define "cloudify-services.postgres_env_vars" -}}
+- name: POSTGRES_HOST
+  value: {{ .Values.db.host }}
+- name: POSTGRES_DB
+  value: {{ .Values.db.dbName }}
+- name: POSTGRES_USER
+  value: {{ .Values.db.user }}
+- name: POSTGRES_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.db.k8sSecret.name }}
+      key: {{ .Values.db.k8sSecret.key }}
+{{- end -}}

--- a/cloudify-services/templates/api-service.yaml
+++ b/cloudify-services/templates/api-service.yaml
@@ -26,8 +26,9 @@ spec:
             - -exuc
             - |
               /opt/rest-service/docker/prepare_secrets.sh
-              python -m manager_rest.configure_manager --db-wait postgresql
+              python -m manager_rest.configure_manager --db-wait $POSTGRES_HOST
           env:
+            {{- include "cloudify-services.postgres_env_vars" . | nindent 12 }}
             - name: ENTRYPOINT
               value: localhost
       containers:
@@ -42,6 +43,8 @@ spec:
             capabilities:
               drop:
                 - ALL
+          env:
+            {{- include "cloudify-services.postgres_env_vars" . | nindent 12 }}
           ports:
             - containerPort: {{ .Values.api_service.port }}
           {{- if .Values.api_service.probes.liveness.enabled }}

--- a/cloudify-services/templates/composer-backend.yaml
+++ b/cloudify-services/templates/composer-backend.yaml
@@ -28,7 +28,7 @@ spec:
           imagePullPolicy: {{ .Values.composer_backend.imagePullPolicy }}
           securityContext:
             allowPrivilegeEscalation: false
-            runAsNonRoot: true
+            runAsNonRoot: {{ .Values.composer_backend.securityContext.runAsNonRoot }}
             seccompProfile:
               type: RuntimeDefault
             capabilities:

--- a/cloudify-services/templates/composer-backend.yaml
+++ b/cloudify-services/templates/composer-backend.yaml
@@ -17,6 +17,7 @@ spec:
     spec:
       containers:
         - env:
+            {{- include "cloudify-services.postgres_env_vars" . | nindent 12 }}
             - name: RESTSERVICE_ADDRESS
               value: cloudify-entrypoint
             - name: RESTSERVICE_PROTOCOL

--- a/cloudify-services/templates/composer-frontend.yaml
+++ b/cloudify-services/templates/composer-frontend.yaml
@@ -20,7 +20,7 @@ spec:
           imagePullPolicy: {{ .Values.composer_frontend.imagePullPolicy }}
           securityContext:
             allowPrivilegeEscalation: false
-            runAsNonRoot: true
+            runAsNonRoot: {{ .Values.composer_frontend.securityContext.runAsNonRoot }}
             readOnlyRootFilesystem: true
             seccompProfile:
               type: RuntimeDefault

--- a/cloudify-services/templates/execution-scheduler.yaml
+++ b/cloudify-services/templates/execution-scheduler.yaml
@@ -18,6 +18,8 @@ spec:
       containers:
         - image: {{ .Values.execution_scheduler.image }}
           imagePullPolicy: {{ .Values.execution_scheduler.imagePullPolicy }}
+          env:
+            {{- include "cloudify-services.postgres_env_vars" . | nindent 12 }}
           securityContext:
             allowPrivilegeEscalation: false
             runAsNonRoot: true

--- a/cloudify-services/templates/mgmtworker.yaml
+++ b/cloudify-services/templates/mgmtworker.yaml
@@ -71,8 +71,10 @@ spec:
             - |
               /opt/rest-service/docker/prepare_secrets.sh
               python -m manager_rest.configure_manager --rabbitmq-wait rabbitmq
-              python -m manager_rest.configure_manager --db-wait postgresql
+              python -m manager_rest.configure_manager --db-wait $POSTGRES_HOST
               python -m manager_rest.configure_manager --create-admin-token /opt/mgmtworker/work/admin_token
+          env:
+            {{- include "cloudify-services.postgres_env_vars" . | nindent 12 }}
           volumeMounts:
             - mountPath: /etc/cloudify/ssl
               name: ssl

--- a/cloudify-services/templates/mgmtworker.yaml
+++ b/cloudify-services/templates/mgmtworker.yaml
@@ -39,7 +39,7 @@ roleRef:
   name: mgmtworker-role
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: mgmtworker
 spec:
@@ -119,3 +119,12 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
       {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mgmtworker
+spec:
+  selector:
+    app: mgmtworker
+  clusterIP: None

--- a/cloudify-services/templates/rest-service.yaml
+++ b/cloudify-services/templates/rest-service.yaml
@@ -26,12 +26,14 @@ spec:
             - -exuc
             - |
               /opt/rest-service/docker/prepare_secrets.sh
-              python -m manager_rest.configure_manager --db-wait postgresql
+              python -m manager_rest.configure_manager --db-wait $POSTGRES_HOST
 
               cd /opt/rest-service/migrations
               alembic upgrade head
 
               python -m manager_rest.configure_manager -c "{{ .Values.rest_service.configPath }}"
+          env:
+            {{- include "cloudify-services.postgres_env_vars" . | nindent 12 }}
           volumeMounts:
             - mountPath: /etc/cloudify/ssl
               name: ssl
@@ -150,6 +152,7 @@ spec:
           image: {{ .Values.rest_service.image }}
           imagePullPolicy: {{ .Values.rest_service.imagePullPolicy }}
           env:
+            {{- include "cloudify-services.postgres_env_vars" . | nindent 12 }}
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:

--- a/cloudify-services/templates/stage-backend.yaml
+++ b/cloudify-services/templates/stage-backend.yaml
@@ -17,6 +17,7 @@ spec:
     spec:
       containers:
         - env:
+            {{- include "cloudify-services.postgres_env_vars" . | nindent 12 }}
             - name: RESTSERVICE_ADDRESS
               value: cloudify-entrypoint
             - name: RESTSERVICE_PROTOCOL

--- a/cloudify-services/templates/stage-backend.yaml
+++ b/cloudify-services/templates/stage-backend.yaml
@@ -28,7 +28,7 @@ spec:
           imagePullPolicy: {{ .Values.stage_backend.imagePullPolicy }}
           securityContext:
             allowPrivilegeEscalation: false
-            runAsNonRoot: true
+            runAsNonRoot: {{ .Values.stage_backend.securityContext.runAsNonRoot }}
             seccompProfile:
               type: RuntimeDefault
             capabilities:

--- a/cloudify-services/templates/stage-frontend.yaml
+++ b/cloudify-services/templates/stage-frontend.yaml
@@ -20,7 +20,7 @@ spec:
           imagePullPolicy: {{ .Values.stage_frontend.imagePullPolicy }}
           securityContext:
             allowPrivilegeEscalation: false
-            runAsNonRoot: true
+            runAsNonRoot: {{ .Values.stage_frontend.securityContext.runAsNonRoot }}
             readOnlyRootFilesystem: true
             seccompProfile:
               type: RuntimeDefault

--- a/cloudify-services/values.yaml
+++ b/cloudify-services/values.yaml
@@ -53,6 +53,8 @@ composer_backend:
       timeoutSeconds: 10
       successThreshold: 1
       failureThreshold: 3
+  securityContext:
+    runAsNonRoot: true
 
 composer_frontend:
   replicas: 1
@@ -67,6 +69,8 @@ composer_frontend:
       timeoutSeconds: 10
       successThreshold: 1
       failureThreshold: 3
+  securityContext:
+    runAsNonRoot: true
 
 execution_scheduler:
   replicas: 1
@@ -365,6 +369,8 @@ stage_backend:
       timeoutSeconds: 10
       successThreshold: 1
       failureThreshold: 3
+  securityContext:
+    runAsNonRoot: true
 
 stage_frontend:
   replicas: 1
@@ -379,6 +385,8 @@ stage_frontend:
       timeoutSeconds: 10
       successThreshold: 1
       failureThreshold: 3
+  securityContext:
+    runAsNonRoot: true
 
 prometheus:
   replicas: 1


### PR DESCRIPTION
This is several mostly-unrelated items, but notably, we'll allow configuring postgresql connection details for containers. Main point being, now we can set the postgresql db hostname - when using architecture=replicated with the bitnami postgres chart, the primary's hostname is "postgresql-primary"