### PR TITLE
NE-7791 Compatibility with replicated postgresql

### DIFF
--- a/cloudify-services/dockerhub-values.yaml
+++ b/cloudify-services/dockerhub-values.yaml
@@ -13,9 +13,6 @@ execution_scheduler:
 mgmtworker:
   image: docker.io/cloudifyplatform/cloudify-manager-mgmtworker:7.0.3
 
-rabbitmq:
-  image: docker.io/cloudifyplatform/cloudify-manager-rabbitmq:7.0.3
-
 rest_service:
   image: docker.io/cloudifyplatform/cloudify-manager-restservice:7.0.3
 

--- a/cloudify-services/scaled-up-values.yaml
+++ b/cloudify-services/scaled-up-values.yaml
@@ -1,0 +1,17 @@
+# this is an example values file showing how to scale up several services
+
+# rabbitmq and mgmtworker can be scaled by just increasing the pod count
+rabbitmq:
+  replicaCount: 2
+
+mgmtworker:
+  replicas: 2
+
+# with the bitnami postgresql chart, using architecture=replication will
+# start a primary and a read replica
+postgresql:
+  architecture: replication
+
+# all the db-using services need to be instructed to connect to the primary
+db:
+  host: "postgresql-primary"

--- a/cloudify-services/templates/_helpers.tpl
+++ b/cloudify-services/templates/_helpers.tpl
@@ -109,3 +109,21 @@ Output is a string like:
 {{- end -}}
 {{- printf (join " && " $curls ) -}}
 {{- end -}}
+
+
+{{/*
+Return env vars block with postgresql connection parameters.
+*/}}
+{{- define "cloudify-services.postgres_env_vars" -}}
+- name: POSTGRES_HOST
+  value: {{ .Values.db.host }}
+- name: POSTGRES_DB
+  value: {{ .Values.db.dbName }}
+- name: POSTGRES_USER
+  value: {{ .Values.db.user }}
+- name: POSTGRES_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.db.k8sSecret.name }}
+      key: {{ .Values.db.k8sSecret.key }}
+{{- end -}}

--- a/cloudify-services/templates/api-service.yaml
+++ b/cloudify-services/templates/api-service.yaml
@@ -26,8 +26,9 @@ spec:
             - -exuc
             - |
               /opt/rest-service/docker/prepare_secrets.sh
-              python -m manager_rest.configure_manager --db-wait postgresql
+              python -m manager_rest.configure_manager --db-wait $POSTGRES_HOST
           env:
+            {{- include "cloudify-services.postgres_env_vars" . | nindent 12 }}
             - name: ENTRYPOINT
               value: localhost
       containers:
@@ -42,6 +43,8 @@ spec:
             capabilities:
               drop:
                 - ALL
+          env:
+            {{- include "cloudify-services.postgres_env_vars" . | nindent 12 }}
           ports:
             - containerPort: {{ .Values.api_service.port }}
           {{- if .Values.api_service.probes.liveness.enabled }}

--- a/cloudify-services/templates/composer-backend.yaml
+++ b/cloudify-services/templates/composer-backend.yaml
@@ -17,6 +17,7 @@ spec:
     spec:
       containers:
         - env:
+            {{- include "cloudify-services.postgres_env_vars" . | nindent 12 }}
             - name: RESTSERVICE_ADDRESS
               value: cloudify-entrypoint
             - name: RESTSERVICE_PROTOCOL
@@ -27,6 +28,7 @@ spec:
           imagePullPolicy: {{ .Values.composer_backend.imagePullPolicy }}
           securityContext:
             allowPrivilegeEscalation: false
+            runAsNonRoot: {{ .Values.composer_backend.securityContext.runAsNonRoot }}
             seccompProfile:
               type: RuntimeDefault
             capabilities:

--- a/cloudify-services/templates/composer-frontend.yaml
+++ b/cloudify-services/templates/composer-frontend.yaml
@@ -20,6 +20,7 @@ spec:
           imagePullPolicy: {{ .Values.composer_frontend.imagePullPolicy }}
           securityContext:
             allowPrivilegeEscalation: false
+            runAsNonRoot: {{ .Values.composer_frontend.securityContext.runAsNonRoot }}
             readOnlyRootFilesystem: true
             seccompProfile:
               type: RuntimeDefault

--- a/cloudify-services/templates/execution-scheduler.yaml
+++ b/cloudify-services/templates/execution-scheduler.yaml
@@ -18,6 +18,8 @@ spec:
       containers:
         - image: {{ .Values.execution_scheduler.image }}
           imagePullPolicy: {{ .Values.execution_scheduler.imagePullPolicy }}
+          env:
+            {{- include "cloudify-services.postgres_env_vars" . | nindent 12 }}
           securityContext:
             allowPrivilegeEscalation: false
             runAsNonRoot: true

--- a/cloudify-services/templates/mgmtworker.yaml
+++ b/cloudify-services/templates/mgmtworker.yaml
@@ -39,7 +39,7 @@ roleRef:
   name: mgmtworker-role
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: mgmtworker
 spec:
@@ -77,8 +77,10 @@ spec:
             - |
               /opt/rest-service/docker/prepare_secrets.sh
               python -m manager_rest.configure_manager --rabbitmq-wait rabbitmq
-              python -m manager_rest.configure_manager --db-wait postgresql
+              python -m manager_rest.configure_manager --db-wait $POSTGRES_HOST
               python -m manager_rest.configure_manager --create-admin-token /opt/mgmtworker/work/admin_token
+          env:
+            {{- include "cloudify-services.postgres_env_vars" . | nindent 12 }}
           volumeMounts:
             - mountPath: /etc/cloudify/ssl
               name: ssl
@@ -123,3 +125,12 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
       {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mgmtworker
+spec:
+  selector:
+    app: mgmtworker
+  clusterIP: None

--- a/cloudify-services/templates/rest-service.yaml
+++ b/cloudify-services/templates/rest-service.yaml
@@ -32,12 +32,14 @@ spec:
             - -exuc
             - |
               /opt/rest-service/docker/prepare_secrets.sh
-              python -m manager_rest.configure_manager --db-wait postgresql
+              python -m manager_rest.configure_manager --db-wait $POSTGRES_HOST
 
               cd /opt/rest-service/migrations
               alembic upgrade head
 
               python -m manager_rest.configure_manager -c "{{ .Values.rest_service.configPath }}"
+          env:
+            {{- include "cloudify-services.postgres_env_vars" . | nindent 12 }}
           volumeMounts:
             - mountPath: /etc/cloudify/ssl
               name: ssl
@@ -156,6 +158,7 @@ spec:
           image: {{ .Values.rest_service.image }}
           imagePullPolicy: {{ .Values.rest_service.imagePullPolicy }}
           env:
+            {{- include "cloudify-services.postgres_env_vars" . | nindent 12 }}
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:

--- a/cloudify-services/templates/stage-backend.yaml
+++ b/cloudify-services/templates/stage-backend.yaml
@@ -17,6 +17,7 @@ spec:
     spec:
       containers:
         - env:
+            {{- include "cloudify-services.postgres_env_vars" . | nindent 12 }}
             - name: RESTSERVICE_ADDRESS
               value: cloudify-entrypoint
             - name: RESTSERVICE_PROTOCOL
@@ -27,6 +28,7 @@ spec:
           imagePullPolicy: {{ .Values.stage_backend.imagePullPolicy }}
           securityContext:
             allowPrivilegeEscalation: false
+            runAsNonRoot: {{ .Values.stage_backend.securityContext.runAsNonRoot }}
             seccompProfile:
               type: RuntimeDefault
             capabilities:

--- a/cloudify-services/templates/stage-frontend.yaml
+++ b/cloudify-services/templates/stage-frontend.yaml
@@ -20,6 +20,7 @@ spec:
           imagePullPolicy: {{ .Values.stage_frontend.imagePullPolicy }}
           securityContext:
             allowPrivilegeEscalation: false
+            runAsNonRoot: {{ .Values.stage_frontend.securityContext.runAsNonRoot }}
             readOnlyRootFilesystem: true
             seccompProfile:
               type: RuntimeDefault

--- a/cloudify-services/values.yaml
+++ b/cloudify-services/values.yaml
@@ -53,6 +53,8 @@ composer_backend:
       timeoutSeconds: 10
       successThreshold: 1
       failureThreshold: 3
+  securityContext:
+    runAsNonRoot: true
 
 composer_frontend:
   replicas: 1
@@ -67,6 +69,8 @@ composer_frontend:
       timeoutSeconds: 10
       successThreshold: 1
       failureThreshold: 3
+  securityContext:
+    runAsNonRoot: true
 
 execution_scheduler:
   replicas: 1
@@ -365,6 +369,8 @@ stage_backend:
       timeoutSeconds: 10
       successThreshold: 1
       failureThreshold: 3
+  securityContext:
+    runAsNonRoot: true
 
 stage_frontend:
   replicas: 1
@@ -379,6 +385,8 @@ stage_frontend:
       timeoutSeconds: 10
       successThreshold: 1
       failureThreshold: 3
+  securityContext:
+    runAsNonRoot: true
 
 prometheus:
   replicas: 1


### PR DESCRIPTION
This ports #128 to 7.0.3

* generate certs: add the entrypoint name to the cert SANs

otherwise, stage wont be able to connect to nginx

* Pass postgres connection data to all db-using containers via env

Expose a template in helpers, and use it in all containers that use the db, to give them db access

* frontend containers: parametrize runAsNonRoot

depending on the image, some versions don't really like to run with that enabled. Let's parametrize it for easier development (keep the default the same though)

* make the mgmtworker into a statefulset

This way, hostnames will not be random, which means mgmtworkers won't leak tokens, which are based on the hostname currently