### PR TITLE
Template the seaweedfs instead of hardcoding it

### DIFF
--- a/cloudify-services/templates/_helpers.tpl
+++ b/cloudify-services/templates/_helpers.tpl
@@ -149,3 +149,16 @@ Return env vars block with the secret keys envvars for the restservice.
       name: manager-security
       key: hashSalt
 {{- end -}}
+
+
+{{/*
+Set the s3_server_url parameter: when using builtin seaweedfs, generate the url
+*/}}
+{{- define "cloudify-services.s3_server_url" -}}
+{{- if .Values.seaweedfs.enabled -}}
+  {{- tpl "http://seaweedfs-s3.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.seaweedfs.s3.port }}" . -}}
+{{- else -}}
+  {{- tpl .Values.rest_service.config.manager.s3_server_url . -}}
+{{- end -}}
+{{- end -}}
+

--- a/cloudify-services/templates/rest-service.yaml
+++ b/cloudify-services/templates/rest-service.yaml
@@ -31,7 +31,17 @@ spec:
               cd /opt/rest-service/migrations
               alembic upgrade head
 
-              python -m manager_rest.configure_manager -c "{{ .Values.rest_service.configPath }}"
+              # setup config overrides based on the cluster state/values:
+              # - if using the builtin seaweedfs, set s3_server_url to its fully-qualified address
+              echo '{}'> /tmp/config-overrides.yaml
+              {{- if .Values.seaweedfs.enabled }}
+              cat >/tmp/config-overrides.yaml <<EOF
+              manager:
+                s3_server_url: "{{ include "cloudify-services.s3_server_url" . }}"
+              EOF
+              {{- end }}
+
+              python -m manager_rest.configure_manager -c "{{ .Values.rest_service.configPath }}" -c "/tmp/config-overrides.yaml"
           env:
             {{- include "cloudify-services.postgres_env_vars" . | nindent 12 }}
             {{- include "cloudify-services.restservice_keys" . | nindent 12 }}
@@ -50,7 +60,7 @@ spec:
           command: ['sh', '-c', "aws s3 ls s3://resources || aws s3 mb s3://resources"]
           env:
             - name: AWS_ENDPOINT_URL
-              value: {{ .Values.rest_service.config.manager.s3_server_url }}
+              value: {{ include "cloudify-services.s3_server_url" . }}
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
@@ -125,7 +135,7 @@ spec:
                 - ALL
           env:
             - name: AWS_ENDPOINT_URL
-              value: {{ .Values.rest_service.config.manager.s3_server_url }}
+              value: {{ include "cloudify-services.s3_server_url" . }}
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
@@ -231,4 +241,4 @@ metadata:
   name: rest-service-config
 data:
   config.yaml: |
-    {{ .Values.rest_service.config | toYaml | nindent 4 }}
+    {{ tpl (.Values.rest_service.config | toYaml | nindent 4) . }}

--- a/cloudify-services/values.yaml
+++ b/cloudify-services/values.yaml
@@ -339,7 +339,8 @@ rest_service:
       public_ip: localhost
       file_server_type: s3
       s3_resources_bucket: resources
-      s3_server_url: http://seaweedfs-s3.default.svc.cluster.local:8333
+      # -- s3_server_url is the address of the s3 endpoint. Ignored and auto-generated when using builtin seaweedfs
+      s3_server_url: ""
       prometheus_url: http://prometheus-server:9090
 
 api_service:


### PR DESCRIPTION
When using builtin seaweedfs, generate the url.
The previous approach hardcoded the namespace name, which was of course not very portable.